### PR TITLE
Auth: Integrate session provider AND Handle 401 redirect to login

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { AuthProvider } from "@/context/AuthContext";
 
 const geistSans = Geist({
 	variable: "--font-geist-sans",
@@ -27,7 +28,7 @@ export default function RootLayout({
 			<body
 				className={`${geistSans.variable} ${geistMono.variable} antialiased`}
 			>
-				{children}
+				<AuthProvider>{children}</AuthProvider>
 			</body>
 		</html>
 	);

--- a/src/components/layouts/Sidebar.tsx
+++ b/src/components/layouts/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
 import clsx from "clsx";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useAuth } from "@/context/AuthContext";
 
 const navigation = [
 	{ name: "Dashboard", href: "/demo/dashboard", icon: HomeIcon },
@@ -33,6 +34,7 @@ interface SidebarProps {
 
 export function Sidebar({ isOpen, onClose }: SidebarProps) {
 	const pathname = usePathname();
+	const { user, isLoading } = useAuth();
 
 	return (
 		<>
@@ -102,15 +104,41 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
 
 					{/* User Profile */}
 					<div className="border-t p-4">
-						<div className="flex items-center space-x-3">
-							<div className="h-10 w-10 rounded-full bg-linear-to-br from-gray-300 to-gray-400" />
-							<div className="flex-1 min-w-0">
-								<p className="text-sm font-medium text-gray-900 truncate">
-									Tali Nanzing Moses
-								</p>
-								<p className="text-xs text-gray-500 truncate">User</p>
+						{isLoading ? (
+							<div className="flex items-center space-x-3">
+								<div className="h-10 w-10 rounded-full bg-gray-200 animate-pulse" />
+								<div className="flex-1 space-y-2">
+									<div className="h-3 w-24 rounded bg-gray-200 animate-pulse" />
+									<div className="h-2 w-16 rounded bg-gray-200 animate-pulse" />
+								</div>
 							</div>
-						</div>
+						) : user ? (
+							<div className="flex items-center space-x-3">
+								<div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-linear-to-br from-blue-500 to-purple-600 text-sm font-semibold text-white">
+									{user.name
+										.split(" ")
+										.map((n) => n[0])
+										.slice(0, 2)
+										.join("")
+										.toUpperCase()}
+								</div>
+								<div className="flex-1 min-w-0">
+									<p className="text-sm font-medium text-gray-900 truncate">
+										{user.name}
+									</p>
+									<p className="text-xs text-gray-500 truncate">{user.role}</p>
+								</div>
+							</div>
+						) : (
+							<div className="flex items-center space-x-3">
+								<div className="h-10 w-10 rounded-full bg-linear-to-br from-gray-300 to-gray-400" />
+								<div className="flex-1 min-w-0">
+									<p className="text-sm font-medium text-gray-500 truncate">
+										Not signed in
+									</p>
+								</div>
+							</div>
+						)}
 					</div>
 				</div>
 			</div>

--- a/src/components/layouts/TopNav.tsx
+++ b/src/components/layouts/TopNav.tsx
@@ -8,6 +8,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
+import { useAuth } from "@/context/AuthContext";
 
 interface TopNavProps {
 	onMenuClick: () => void;
@@ -16,6 +17,7 @@ interface TopNavProps {
 export function TopNav({ onMenuClick }: TopNavProps) {
 	const [searchOpen, setSearchOpen] = useState(false);
 	const pathname = usePathname();
+	const { user, isLoading } = useAuth();
 
 	// Get current page title from pathname
 	const pageTitle =
@@ -108,12 +110,27 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 							className="flex items-center gap-x-3 rounded-lg p-1.5 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
 							id="user-menu-button"
 						>
-							<div className="h-8 w-8 rounded-full bg-linear-to-br from-gray-300 to-gray-400" />
-							<div className="hidden lg:block text-left">
-								<p className="text-sm font-medium text-gray-900">
-									Tali Nanzing Moses
-								</p>
-							</div>
+							{isLoading ? (
+								<div className="h-8 w-8 rounded-full bg-gray-200 animate-pulse" />
+							) : user ? (
+								<>
+									<div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-linear-to-br from-blue-500 to-purple-600 text-xs font-semibold text-white">
+										{user.name
+											.split(" ")
+											.map((n) => n[0])
+											.slice(0, 2)
+											.join("")
+											.toUpperCase()}
+									</div>
+									<div className="hidden lg:block text-left">
+										<p className="text-sm font-medium text-gray-900">
+											{user.name}
+										</p>
+									</div>
+								</>
+							) : (
+								<div className="h-8 w-8 rounded-full bg-linear-to-br from-gray-300 to-gray-400" />
+							)}
 							<ChevronDownIcon
 								className="hidden h-5 w-5 text-gray-400 lg:block"
 								aria-hidden="true"

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -14,43 +14,94 @@ export interface AuthUser {
 	role: string;
 }
 
+/** Shape of a persisted session record. */
+interface SessionRecord {
+	user: AuthUser;
+	/** Unix timestamp (ms) when the session expires. */
+	expiresAt: number;
+}
+
 interface AuthContextValue {
 	user: AuthUser | null;
 	isLoading: boolean;
 	isAuthenticated: boolean;
-	signIn: (user: AuthUser) => void;
+	signIn: (user: AuthUser, ttlMs?: number) => void;
 	signOut: () => void;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
-const SESSION_KEY = "mux_auth_user";
+/** sessionStorage key for the user record (client-side rehydration). */
+const SESSION_STORAGE_KEY = "mux_auth_user";
+
+/** Cookie name read by the Next.js middleware for server-side route protection. */
+const SESSION_COOKIE_NAME = "mux_auth_session";
+
+/** Default session lifetime: 8 hours. */
+const DEFAULT_TTL_MS = 8 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Cookie helpers (client-side only)
+// ---------------------------------------------------------------------------
+
+function setSessionCookie(ttlMs: number): void {
+	const maxAge = Math.floor(ttlMs / 1000);
+	// SameSite=Lax is safe for same-origin navigation; Secure is omitted here
+	// so it works on localhost — add "; Secure" in production via a server-set cookie.
+	document.cookie = `${SESSION_COOKIE_NAME}=1; path=/; max-age=${maxAge}; SameSite=Lax`;
+}
+
+function clearSessionCookie(): void {
+	document.cookie = `${SESSION_COOKIE_NAME}=; path=/; max-age=0; SameSite=Lax`;
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
 	const [user, setUser] = useState<AuthUser | null>(null);
 	const [isLoading, setIsLoading] = useState(true);
 
-	// Rehydrate from sessionStorage on mount
+	/** Rehydrate session from sessionStorage on mount and validate expiry. */
 	useEffect(() => {
 		try {
-			const stored = sessionStorage.getItem(SESSION_KEY);
+			const stored = sessionStorage.getItem(SESSION_STORAGE_KEY);
 			if (stored) {
-				setUser(JSON.parse(stored) as AuthUser);
+				const record = JSON.parse(stored) as SessionRecord;
+				if (record.expiresAt > Date.now()) {
+					setUser(record.user);
+					// Re-sync cookie in case it was cleared (e.g. browser restart)
+					const remainingMs = record.expiresAt - Date.now();
+					setSessionCookie(remainingMs);
+				} else {
+					// Session expired — clean up stale data
+					sessionStorage.removeItem(SESSION_STORAGE_KEY);
+					clearSessionCookie();
+				}
 			}
 		} catch {
-			// Ignore parse errors — treat as unauthenticated
+			// Corrupt storage — treat as unauthenticated
+			sessionStorage.removeItem(SESSION_STORAGE_KEY);
+			clearSessionCookie();
 		} finally {
 			setIsLoading(false);
 		}
 	}, []);
 
-	const signIn = useCallback((authUser: AuthUser) => {
-		sessionStorage.setItem(SESSION_KEY, JSON.stringify(authUser));
+	const signIn = useCallback((authUser: AuthUser, ttlMs = DEFAULT_TTL_MS) => {
+		const record: SessionRecord = {
+			user: authUser,
+			expiresAt: Date.now() + ttlMs,
+		};
+		sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(record));
+		setSessionCookie(ttlMs);
 		setUser(authUser);
 	}, []);
 
 	const signOut = useCallback(() => {
-		sessionStorage.removeItem(SESSION_KEY);
+		sessionStorage.removeItem(SESSION_STORAGE_KEY);
+		clearSessionCookie();
 		setUser(null);
 	}, []);
 
@@ -69,10 +120,24 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 	);
 }
 
+/**
+ * Alias exported for issue #40 — "Integrate session provider".
+ * Consumers can import either `AuthProvider` or `SessionProvider`; they are
+ * the same component.
+ */
+export const SessionProvider = AuthProvider;
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
 export function useAuth(): AuthContextValue {
 	const ctx = useContext(AuthContext);
 	if (!ctx) {
-		throw new Error("useAuth must be used within an AuthProvider");
+		throw new Error("useAuth must be used within an AuthProvider / SessionProvider");
 	}
 	return ctx;
 }
+
+/** Convenience alias for `useAuth`. */
+export const useSession = useAuth;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useState,
+} from "react";
+
+export interface AuthUser {
+	name: string;
+	email: string;
+	role: string;
+}
+
+interface AuthContextValue {
+	user: AuthUser | null;
+	isLoading: boolean;
+	isAuthenticated: boolean;
+	signIn: (user: AuthUser) => void;
+	signOut: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+const SESSION_KEY = "mux_auth_user";
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+	const [user, setUser] = useState<AuthUser | null>(null);
+	const [isLoading, setIsLoading] = useState(true);
+
+	// Rehydrate from sessionStorage on mount
+	useEffect(() => {
+		try {
+			const stored = sessionStorage.getItem(SESSION_KEY);
+			if (stored) {
+				setUser(JSON.parse(stored) as AuthUser);
+			}
+		} catch {
+			// Ignore parse errors — treat as unauthenticated
+		} finally {
+			setIsLoading(false);
+		}
+	}, []);
+
+	const signIn = useCallback((authUser: AuthUser) => {
+		sessionStorage.setItem(SESSION_KEY, JSON.stringify(authUser));
+		setUser(authUser);
+	}, []);
+
+	const signOut = useCallback(() => {
+		sessionStorage.removeItem(SESSION_KEY);
+		setUser(null);
+	}, []);
+
+	return (
+		<AuthContext.Provider
+			value={{
+				user,
+				isLoading,
+				isAuthenticated: user !== null,
+				signIn,
+				signOut,
+			}}
+		>
+			{children}
+		</AuthContext.Provider>
+	);
+}
+
+export function useAuth(): AuthContextValue {
+	const ctx = useContext(AuthContext);
+	if (!ctx) {
+		throw new Error("useAuth must be used within an AuthProvider");
+	}
+	return ctx;
+}

--- a/src/hooks/useSessionGuard.ts
+++ b/src/hooks/useSessionGuard.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { useAuth } from "@/context/AuthContext";
+
+/**
+ * useSessionGuard
+ *
+ * Client-side complement to the Next.js middleware route protection (issue #41).
+ * Redirects unauthenticated users to the login page once the auth state has
+ * finished loading, handling the case where the middleware cookie check passes
+ * but the in-memory session is stale or missing (e.g. after a hard refresh
+ * with an expired sessionStorage record).
+ *
+ * Usage — place at the top of any protected page or layout:
+ *
+ *   export default function DashboardPage() {
+ *     useSessionGuard();
+ *     // ...
+ *   }
+ *
+ * @param redirectTo - Path to redirect unauthenticated users to (default: "/")
+ */
+export function useSessionGuard(redirectTo = "/"): void {
+	const { isAuthenticated, isLoading } = useAuth();
+	const router = useRouter();
+
+	useEffect(() => {
+		if (isLoading) return;
+
+		if (!isAuthenticated) {
+			const callbackUrl = encodeURIComponent(window.location.pathname);
+			router.replace(`${redirectTo}?callbackUrl=${callbackUrl}`);
+		}
+	}, [isAuthenticated, isLoading, redirectTo, router]);
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,51 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+/**
+ * Protected route prefixes.
+ * Any request whose pathname starts with one of these values requires
+ * the user to be authenticated (indicated by the presence of the
+ * `mux_auth_session` cookie set during sign-in).
+ */
+const PROTECTED_PREFIXES = ["/demo/dashboard"];
+
+/**
+ * The path users are redirected to when they are not authenticated.
+ * A `callbackUrl` query param is appended so the login page can
+ * redirect back after a successful sign-in.
+ */
+const LOGIN_PATH = "/";
+
+export function middleware(request: NextRequest) {
+	const { pathname } = request.nextUrl;
+
+	const isProtected = PROTECTED_PREFIXES.some((prefix) =>
+		pathname.startsWith(prefix),
+	);
+
+	if (!isProtected) {
+		return NextResponse.next();
+	}
+
+	const session = request.cookies.get("mux_auth_session");
+
+	if (!session?.value) {
+		const loginUrl = request.nextUrl.clone();
+		loginUrl.pathname = LOGIN_PATH;
+		loginUrl.searchParams.set("callbackUrl", pathname);
+		return NextResponse.redirect(loginUrl);
+	}
+
+	return NextResponse.next();
+}
+
+export const config = {
+	/*
+	 * Match all routes under /demo/dashboard.
+	 * Exclude Next.js internals and static assets so they are never blocked.
+	 */
+	matcher: [
+		"/demo/dashboard",
+		"/demo/dashboard/:path*",
+	],
+};

--- a/src/utils/fetchWithAuth.ts
+++ b/src/utils/fetchWithAuth.ts
@@ -1,0 +1,78 @@
+/**
+ * fetchWithAuth
+ *
+ * A thin wrapper around the native `fetch` API that handles 401 Unauthorized
+ * responses by clearing the client session and redirecting the user to the
+ * login page (issue #43).
+ *
+ * Usage:
+ *   import { fetchWithAuth } from "@/utils/fetchWithAuth";
+ *   const data = await fetchWithAuth("/api/wallets");
+ */
+
+/** Cookie / sessionStorage key — must match AuthContext constants. */
+const SESSION_COOKIE_NAME = "mux_auth_session";
+const SESSION_STORAGE_KEY = "mux_auth_user";
+
+/** The path users are sent to after a 401. */
+const LOGIN_PATH = "/";
+
+function clearClientSession(): void {
+	try {
+		sessionStorage.removeItem(SESSION_STORAGE_KEY);
+	} catch {
+		// sessionStorage unavailable (SSR / private browsing edge case)
+	}
+	// Expire the session cookie immediately
+	document.cookie = `${SESSION_COOKIE_NAME}=; path=/; max-age=0; SameSite=Lax`;
+}
+
+function redirectToLogin(currentPath?: string): void {
+	const url = new URL(LOGIN_PATH, window.location.origin);
+	if (currentPath) {
+		url.searchParams.set("callbackUrl", currentPath);
+	}
+	window.location.replace(url.toString());
+}
+
+/**
+ * Wraps `fetch` and intercepts 401 responses.
+ *
+ * On a 401:
+ *  1. Clears the client-side session (sessionStorage + cookie).
+ *  2. Redirects to the login page with a `callbackUrl` so the user can
+ *     return after re-authenticating.
+ *  3. Throws an `UnauthorizedError` so callers can handle it if needed.
+ *
+ * All other responses (including other error codes) are returned as-is,
+ * leaving error handling to the caller.
+ */
+export async function fetchWithAuth(
+	input: RequestInfo | URL,
+	init?: RequestInit,
+): Promise<Response> {
+	const response = await fetch(input, init);
+
+	if (response.status === 401) {
+		clearClientSession();
+
+		const callbackUrl =
+			typeof window !== "undefined" ? window.location.pathname : undefined;
+
+		redirectToLogin(callbackUrl);
+
+		throw new UnauthorizedError(
+			"Session expired or invalid. Redirecting to login.",
+		);
+	}
+
+	return response;
+}
+
+/** Thrown by `fetchWithAuth` when a 401 response is received. */
+export class UnauthorizedError extends Error {
+	constructor(message = "Unauthorized") {
+		super(message);
+		this.name = "UnauthorizedError";
+	}
+}


### PR DESCRIPTION
Closes #40 
Closes #43 

Issue #40 - Authentication: Integrate session provider
- Upgraded AuthContext to a full session provider with TTL-based expiry
- signIn() now accepts an optional ttlMs param (default 8 hours)
- Session is persisted as a SessionRecord { user, expiresAt } in sessionStorage
- Sets/clears the mux_auth_session cookie (read by middleware) in sync with
  the in-memory state, so server-side and client-side auth stay consistent


Issue #43 - Handle 401 redirect to login:
- Added src/utils/fetchWithAuth.ts: a fetch wrapper that intercepts 401 responses, clears the client session (sessionStorage + cookie), and redirects to / with a callbackUrl query param
- Throws UnauthorizedError after redirect so callers can catch if needed
- Added src/hooks/useSessionGuard.ts: client-side route guard hook that redirects unauthenticated users after auth state loads, covering the edge case where the middleware cookie passes but sessionStorage is stale
