### PR TITLE
feat(wallets): add functional empty state UI

### DIFF
--- a/src/app/dashboard/wallets/page.tsx
+++ b/src/app/dashboard/wallets/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useState } from "react";
+import { AddWalletModal } from "@/components/wallet/AddWalletModal";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { WalletTable } from "@/components/wallet/WalletTable";
@@ -7,7 +9,15 @@ import { dummyWallets } from "@/mock-data/wallets";
 import type { Wallet } from "@/types/wallet";
 
 export default function WalletsPage() {
-	const wallets: Wallet[] = dummyWallets;
+	const [wallets, setWallets] = useState<Wallet[]>(dummyWallets);
+	const [isAddOpen, setIsAddOpen] = useState(false);
+
+	const openAddWallet = () => setIsAddOpen(true);
+
+	const handleAdd = (wallet: Wallet) => {
+		setWallets((prev) => [wallet, ...prev]);
+		setIsAddOpen(false);
+	};
 
 	return (
 		<div className="space-y-8">
@@ -17,17 +27,23 @@ export default function WalletsPage() {
 			/>
 
 			{wallets.length > 0 ? (
-				<WalletTable wallets={wallets} />
+				<WalletTable wallets={wallets} onAddWallet={openAddWallet} />
 			) : (
 				<EmptyState
 					title="No wallets found"
 					description="You haven't added any wallets to monitor yet. Add your first wallet to start tracking."
 					action={{
 						label: "Add Wallet",
-						onClick: () => {},
+						onClick: openAddWallet,
 					}}
 				/>
 			)}
+
+			<AddWalletModal
+				isOpen={isAddOpen}
+				onClose={() => setIsAddOpen(false)}
+				onAdd={handleAdd}
+			/>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
Adds a functional empty state to the Wallets monitoring page. The page now tracks wallet state and the empty-state "Add Wallet" CTA (and the table's Add Wallet button) opens the AddWalletModal; newly added wallets appear in the list.

## Validation
- biome check (clean)
- tsc --noEmit (no new errors)

Closes #221