### PR TITLE
feat(wallets): wire wallets page to backend API

### DIFF
--- a/src/app/dashboard/wallets/page.tsx
+++ b/src/app/dashboard/wallets/page.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { EmptyState } from "@/components/ui/EmptyState";
+import { ErrorState } from "@/components/ui/ErrorState";
 import { PageHeader } from "@/components/ui/PageHeader";
+import { Skeleton } from "@/components/ui/Skeleton";
 import { WalletTable } from "@/components/wallet/WalletTable";
-import { dummyWallets } from "@/mock-data/wallets";
-import type { Wallet } from "@/types/wallet";
+import { useWallets } from "@/hooks/useWallets";
 
 export default function WalletsPage() {
-	const wallets: Wallet[] = dummyWallets;
+	const { wallets, loading, error, refetch } = useWallets();
 
 	return (
 		<div className="space-y-8">
@@ -16,7 +17,15 @@ export default function WalletsPage() {
 				description="Track and manage your Stellar wallets"
 			/>
 
-			{wallets.length > 0 ? (
+			{loading ? (
+				<div className="space-y-3 rounded-xl border border-zinc-200 p-6 dark:border-zinc-800">
+					{Array.from({ length: 4 }).map((_, i) => (
+						<Skeleton key={i} className="h-12 w-full" />
+					))}
+				</div>
+			) : error ? (
+				<ErrorState description={error} retry={{ onRetry: refetch }} />
+			) : wallets.length > 0 ? (
 				<WalletTable wallets={wallets} />
 			) : (
 				<EmptyState


### PR DESCRIPTION
## Summary
Replaces the hardcoded `dummyWallets` on the Wallets monitoring page with live data from the `useWallets()` hook (`GET /wallets`). Adds loading (skeletons), error (with retry), empty, and populated states.

## Validation
- biome check (clean)
- tsc --noEmit (no new errors)

Closes #220