### PR TITLE
test(wallets): add component tests for wallets page

### DIFF
--- a/src/app/dashboard/wallets/page.test.tsx
+++ b/src/app/dashboard/wallets/page.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("WalletsPage (/dashboard/wallets)", () => {
+	afterEach(() => {
+		vi.resetModules();
+		vi.doUnmock("@/mock-data/wallets");
+	});
+
+	async function renderPage() {
+		const { default: WalletsPage } = await import(
+			"@/app/dashboard/wallets/page"
+		);
+		render(<WalletsPage />);
+	}
+
+	describe("page header", () => {
+		it("renders the heading and description", async () => {
+			await renderPage();
+			expect(
+				screen.getByRole("heading", { name: /wallet monitoring/i }),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(/track and manage your stellar wallets/i),
+			).toBeInTheDocument();
+		});
+	});
+
+	describe("with wallets data", () => {
+		it("renders the WalletTable", async () => {
+			await renderPage();
+			expect(screen.getByRole("table")).toBeInTheDocument();
+		});
+
+		it("does not render the EmptyState", async () => {
+			await renderPage();
+			expect(
+				screen.queryByText(/you haven't added any wallets/i),
+			).not.toBeInTheDocument();
+		});
+	});
+
+	describe("empty state", () => {
+		it("renders the EmptyState when there are no wallets", async () => {
+			vi.resetModules();
+			vi.doMock("@/mock-data/wallets", () => ({ dummyWallets: [] }));
+			await renderPage();
+			expect(screen.getByText(/no wallets found/i)).toBeInTheDocument();
+			expect(
+				screen.getByRole("button", { name: /add wallet/i }),
+			).toBeInTheDocument();
+			expect(screen.queryByRole("table")).not.toBeInTheDocument();
+		});
+	});
+});


### PR DESCRIPTION
## Summary
Adds component tests for the Wallets monitoring page (`/dashboard/wallets`): verifies the header, the populated table state, and the empty state (no wallets) with its Add Wallet CTA.

## Validation
- biome check (clean)
- vitest: 4/4 tests pass

Closes #219