### PR TITLE
feat: Wallet detail page — wire to backend API (#235)

### DIFF
--- a/src/hooks/useWalletBalance.ts
+++ b/src/hooks/useWalletBalance.ts
@@ -1,8 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { dummyWallets } from "@/mock-data/wallets";
 import type { Wallet } from "@/types/wallet";
+import { normalizeWallet } from "@/utils/walletSerialization";
 
 export interface WalletBalanceState {
 	wallet: Wallet | null;
@@ -13,15 +13,16 @@ export interface WalletBalanceState {
 	refresh: () => void;
 }
 
-/** Simulates fetching a wallet's live balance from the backend. */
 async function fetchWalletBalance(id: string): Promise<Wallet> {
-	// Simulate network latency
-	await new Promise((resolve) => setTimeout(resolve, 600));
+	const res = await fetch(`/api/wallets/${encodeURIComponent(id)}`);
+	if (res.status === 404) throw new Error("Wallet not found");
+	if (!res.ok) throw new Error(`Request failed: ${res.status}`);
 
-	const wallet = dummyWallets.find((w) => w.id === id);
-	if (!wallet) {
-		throw new Error(`Wallet ${id} not found`);
-	}
+	const data = (await res.json()) as Wallet & {
+		createdAt: string;
+		lastActivity?: string | null;
+	};
+	const wallet = normalizeWallet(data);
 
 	// Simulate a live balance with minor fluctuation for demo purposes
 	const base = Number.parseFloat(


### PR DESCRIPTION
## Summary

- Replaces direct mock-data access in `useWalletBalance` with a real HTTP call to `GET /api/wallets/:id`
- Removes the `dummyWallets` import from the hook; all wallet data now flows through the API layer
- Uses `normalizeWallet` to deserialise date strings returned by the endpoint into `Date` objects
- 404 responses surface as `"Wallet not found"` so the UI can distinguish a missing wallet from a network failure
- Balance simulation (±1 XLM jitter) is retained on top of the API response because no dedicated live-balance endpoint exists yet

## Motivation

`useWalletBalance` was reading directly from the in-memory `dummyWallets` array, bypassing the API layer entirely. This meant the component never exercised the real request/response cycle, error handling, or serialisation logic. Wiring it to `GET /api/wallets/:id` aligns it with `useWallet` / `useWallets` and makes the full error path testable.

## Changes

- `src/hooks/useWalletBalance.ts` — replaces mock lookup with `fetch('/api/wallets/:id')`, adds `normalizeWallet` call, throws typed 404 error

## Test plan

- [ ] Visit `/demo/dashboard/wallets/<valid-id>` — wallet info and balance load; balance refreshes on the 30 s polling interval
- [ ] Visit `/demo/dashboard/wallets/invalid-id` — error state renders with "Wallet not found"
- [ ] `useWallets` and `useWallet` behaviour is unchanged

closes #235 