### PR TITLE
feat: Wallet detail page — add empty state UI (#236)

### DIFF
--- a/src/components/wallet/WalletDetail.tsx
+++ b/src/components/wallet/WalletDetail.tsx
@@ -2,6 +2,7 @@
 
 import { Check, Copy, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { ErrorState } from "@/components/ui/ErrorState";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { NetworkBadge } from "@/components/wallet/NetworkBadge";
@@ -20,11 +21,33 @@ export function WalletDetail({ id }: WalletDetailProps) {
 		useWalletBalance(id);
 	const { copy, copied } = useCopyToClipboard();
 
+	const isNotFound =
+		!!error &&
+		(error.toLowerCase().includes("not found") || error === "not_found");
+
+	if (isNotFound) {
+		return (
+			<EmptyState
+				title="Wallet not found"
+				description="No wallet exists for this ID. It may have been removed or the link is invalid."
+			/>
+		);
+	}
+
 	if (error && !wallet) {
 		return (
 			<ErrorState
 				description={error}
 				retry={{ label: "Retry", onRetry: refresh }}
+			/>
+		);
+	}
+
+	if (!loading && !wallet) {
+		return (
+			<EmptyState
+				title="No wallet data"
+				description="This wallet has no data to display yet."
 			/>
 		);
 	}


### PR DESCRIPTION
## Summary

- Adds an `EmptyState` when a wallet ID returns 404 ("Wallet not found") — distinct from a generic network error
- Adds a fallback `EmptyState` for the edge case where loading completes but the wallet is `null` and no error is set
- Differentiates the not-found path from other failures so users get the right message and action

## Motivation

Previously, a missing wallet ID showed the same generic `ErrorState` as a network failure, offering a "Retry" button that could never succeed. Users navigating to a stale or invalid wallet link now see a clear "Wallet not found" message instead of a confusing error state.

## Changes

- `src/components/wallet/WalletDetail.tsx`
  - Imports `EmptyState`
  - Checks `error` for `"not found"` / `"not_found"` and renders `EmptyState` before the generic `ErrorState` guard
  - Adds a `!loading && !wallet` guard that renders `EmptyState` as a defensive fallback

## Test plan

- [ ] Navigate to `/demo/dashboard/wallets/invalid-id` — "Wallet not found" empty state renders (no Retry button)
- [ ] Navigate to `/demo/dashboard/wallets/<valid-id>` — wallet detail renders normally, no regressions
- [ ] Network error (e.g., kill the dev server mid-load) — generic `ErrorState` with Retry still appears

closes #236 