### PR TITLE
feat: Wallet detail page — add error state UI (#237)

### DIFF
--- a/src/components/wallet/WalletDetail.tsx
+++ b/src/components/wallet/WalletDetail.tsx
@@ -21,10 +21,21 @@ export function WalletDetail({ id }: WalletDetailProps) {
 	const { copy, copied } = useCopyToClipboard();
 
 	if (error && !wallet) {
+		const isNotFound =
+			error.toLowerCase().includes("not found") || error === "not_found";
 		return (
 			<ErrorState
-				description={error}
-				retry={{ label: "Retry", onRetry: refresh }}
+				title={isNotFound ? "Wallet not found" : "Failed to load wallet"}
+				description={
+					isNotFound
+						? "This wallet doesn't exist or the ID is invalid."
+						: `${error}. Check your connection and try again.`
+				}
+				retry={
+					isNotFound
+						? undefined
+						: { label: "Try Again", onRetry: refresh }
+				}
 			/>
 		);
 	}
@@ -66,7 +77,12 @@ export function WalletDetail({ id }: WalletDetailProps) {
 				)}
 
 				{error && wallet && (
-					<p className="mt-2 text-sm text-red-600 dark:text-red-400">{error}</p>
+					<p
+						role="alert"
+						className="mt-2 text-sm text-red-600 dark:text-red-400"
+					>
+						Balance refresh failed: {error}
+					</p>
 				)}
 			</div>
 


### PR DESCRIPTION
## Summary

- Differentiates "wallet not found" (404) from generic network/server errors in `WalletDetail`
- Shows a contextual title — "Wallet not found" vs. "Failed to load wallet" — rather than the generic "Something went wrong"
- Omits the Retry button for 404 errors (retrying can never succeed for a missing wallet)
- Prefixes inline balance-refresh errors with "Balance refresh failed:" to make the scope of the error clear

## Motivation

The previous implementation passed the raw error string to `ErrorState` with the default title "Something went wrong". Users had no way to tell whether the problem was a missing wallet, a network blip, or a server fault. This change gives each error scenario a distinct title and appropriate recovery action.

## Changes

- `src/components/wallet/WalletDetail.tsx`
  - Detects not-found errors (message contains `"not found"` or equals `"not_found"`)
  - Renders `ErrorState` with `title="Wallet not found"` and no retry for 404 path
  - Renders `ErrorState` with `title="Failed to load wallet"` and a Retry button for other errors
  - Adds `role="alert"` to the inline balance-refresh error paragraph

## Test plan

- [ ] `useWalletBalance` returns a not-found error → "Wallet not found" title, no Retry button
- [ ] `useWalletBalance` returns a network error → "Failed to load wallet" title, Retry button present
- [ ] Balance refresh fails after wallet loaded → inline "Balance refresh failed: …" message appears
- [ ] Happy path — valid wallet loads without showing any error state

closes #237 