### PR TITLE
feat(wallet-detail): add responsive layout (#239)

### DIFF
--- a/src/app/wallet/page.tsx
+++ b/src/app/wallet/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { Suspense, useEffect, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
+import TransactionsTable from "@/components/TransactionsTable/TransactionsTable";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { ErrorState } from "@/components/ui/ErrorState";
@@ -14,7 +15,6 @@ import { useWallets } from "@/hooks/useWallets";
 import { isValidStellarAddress } from "@/utils/addressValidation";
 import { formatDate } from "@/utils/dateFormatting";
 import { isWalletFunded } from "@/utils/walletUtils";
-import TransactionsTable from "@/components/TransactionsTable/TransactionsTable";
 
 function WalletPageContent() {
 	const { wallets, loading, error, refetch } = useWallets();
@@ -42,25 +42,27 @@ function WalletPageContent() {
 	};
 
 	return (
-		<div className="min-h-screen bg-neutral-50 text-neutral-900 font-sans p-6 md:p-12">
-			<div className="max-w-4xl mx-auto space-y-8">
-				<header className="flex items-center justify-between mb-8">
-					<div>
-						<h1 className="text-3xl font-bold tracking-tight text-neutral-900">
+		<div className="min-h-screen bg-neutral-50 text-neutral-900 font-sans p-4 sm:p-6 md:p-12">
+			<div className="max-w-4xl mx-auto space-y-6 sm:space-y-8">
+				<header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between mb-6 sm:mb-8">
+					<div className="min-w-0">
+						<h1 className="text-2xl font-bold tracking-tight text-neutral-900 sm:text-3xl">
 							Wallet Details
 						</h1>
 						{wallet ? (
-							<p className="text-neutral-500 mt-1">{wallet.address}</p>
+							<p className="text-neutral-500 mt-1 break-all text-sm sm:text-base">
+								{wallet.address}
+							</p>
 						) : (
 							<p className="text-neutral-500 mt-1">
 								Manage and view your wallet assets
 							</p>
 						)}
 					</div>
-					<div className="flex gap-3">
+					<div className="flex shrink-0 gap-3">
 						<Link
 							href="/"
-							className="px-4 py-2 text-sm font-medium text-neutral-600 bg-white border border-neutral-200 rounded-lg shadow-xs hover:bg-neutral-50 transition-colors"
+							className="px-4 py-2 text-sm font-medium text-neutral-600 bg-white border border-neutral-200 rounded-lg shadow-xs hover:bg-neutral-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
 						>
 							Back to Dashboard
 						</Link>
@@ -93,8 +95,8 @@ function WalletPageContent() {
 				)}
 
 				{!loading && wallet && (
-					<section className="rounded-2xl border border-neutral-200 bg-white p-8 shadow-sm space-y-6">
-						<dl className="grid gap-6 sm:grid-cols-2">
+					<section className="rounded-2xl border border-neutral-200 bg-white p-4 sm:p-8 shadow-sm space-y-6">
+						<dl className="grid gap-4 sm:gap-6 sm:grid-cols-2">
 							<div>
 								<dt className="text-sm font-medium text-neutral-500">
 									Network
@@ -190,12 +192,12 @@ function WalletPageContent() {
 										</svg>
 										Send
 									</Button>
-										<Button
-											variant="outline"
-											onClick={openReceive}
-											disabled={!canReceive}
-											title={
-												canReceive
+									<Button
+										variant="outline"
+										onClick={openReceive}
+										disabled={!canReceive}
+										title={
+											canReceive
 												? "Show receive QR stub"
 												: "Wallet address is invalid"
 										}

--- a/src/components/wallet/WalletDetail.tsx
+++ b/src/components/wallet/WalletDetail.tsx
@@ -30,10 +30,10 @@ export function WalletDetail({ id }: WalletDetailProps) {
 	}
 
 	return (
-		<div className="space-y-6">
+		<div className="space-y-4 sm:space-y-6">
 			{/* Balance card */}
-			<div className="rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-				<div className="mb-4 flex items-center justify-between">
+			<div className="rounded-xl border border-zinc-200 bg-white p-4 sm:p-6 dark:border-zinc-800 dark:bg-zinc-900">
+				<div className="mb-4 flex flex-wrap items-center justify-between gap-2">
 					<h2 className="text-sm font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
 						Live Balance
 					</h2>
@@ -48,7 +48,7 @@ export function WalletDetail({ id }: WalletDetailProps) {
 							onClick={refresh}
 							disabled={loading}
 							aria-label="Refresh balance"
-							className="rounded-md p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600 disabled:opacity-50 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+							className="rounded-md p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600 disabled:opacity-50 dark:hover:bg-zinc-800 dark:hover:text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
 						>
 							<RefreshCw
 								className={`h-4 w-4 ${loading ? "animate-spin" : ""}`}
@@ -58,9 +58,9 @@ export function WalletDetail({ id }: WalletDetailProps) {
 				</div>
 
 				{loading && !balance ? (
-					<Skeleton className="h-12 w-48" />
+					<Skeleton className="h-10 w-40 sm:h-12 sm:w-48" />
 				) : (
-					<p className="text-4xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
+					<p className="text-3xl font-bold tracking-tight text-zinc-900 sm:text-4xl dark:text-zinc-50">
 						{balance ?? "—"}
 					</p>
 				)}
@@ -72,23 +72,24 @@ export function WalletDetail({ id }: WalletDetailProps) {
 
 			{/* Wallet metadata */}
 			{wallet ? (
-				<div className="rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+				<div className="rounded-xl border border-zinc-200 bg-white p-4 sm:p-6 dark:border-zinc-800 dark:bg-zinc-900">
 					<h2 className="mb-4 text-sm font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
 						Wallet Info
 					</h2>
 					<dl className="space-y-4">
-						<div className="flex items-center justify-between">
+						<div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
 							<dt className="text-sm text-zinc-500 dark:text-zinc-400">
 								Address
 							</dt>
-							<dd className="flex items-center gap-2">
-								<code className="rounded bg-zinc-100 px-2 py-1 font-mono text-sm text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
+							<dd className="flex min-w-0 items-center gap-2">
+								<code className="min-w-0 truncate rounded bg-zinc-100 px-2 py-1 font-mono text-sm text-zinc-700 sm:max-w-[200px] dark:bg-zinc-800 dark:text-zinc-300">
 									{truncateAddress(wallet.address)}
 								</code>
 								<Button
 									variant="ghost"
 									size="icon-sm"
 									onClick={() => copy(wallet.address)}
+									aria-label={copied ? "Address copied" : "Copy wallet address"}
 									title={copied ? "Copied!" : "Copy address"}
 								>
 									{copied ? (
@@ -99,7 +100,7 @@ export function WalletDetail({ id }: WalletDetailProps) {
 								</Button>
 							</dd>
 						</div>
-						<div className="flex items-center justify-between">
+						<div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
 							<dt className="text-sm text-zinc-500 dark:text-zinc-400">
 								Network
 							</dt>
@@ -107,7 +108,7 @@ export function WalletDetail({ id }: WalletDetailProps) {
 								<NetworkBadge network={wallet.network} />
 							</dd>
 						</div>
-						<div className="flex items-center justify-between">
+						<div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
 							<dt className="text-sm text-zinc-500 dark:text-zinc-400">
 								Status
 							</dt>
@@ -115,7 +116,7 @@ export function WalletDetail({ id }: WalletDetailProps) {
 								<StatusIndicator status={wallet.status} />
 							</dd>
 						</div>
-						<div className="flex items-center justify-between">
+						<div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
 							<dt className="text-sm text-zinc-500 dark:text-zinc-400">
 								Created
 							</dt>
@@ -124,7 +125,7 @@ export function WalletDetail({ id }: WalletDetailProps) {
 							</dd>
 						</div>
 						{wallet.lastActivity && (
-							<div className="flex items-center justify-between">
+							<div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
 								<dt className="text-sm text-zinc-500 dark:text-zinc-400">
 									Last Activity
 								</dt>
@@ -136,7 +137,7 @@ export function WalletDetail({ id }: WalletDetailProps) {
 					</dl>
 				</div>
 			) : (
-				<div className="rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+				<div className="rounded-xl border border-zinc-200 bg-white p-4 sm:p-6 dark:border-zinc-800 dark:bg-zinc-900">
 					<Skeleton className="mb-4 h-4 w-24" />
 					<div className="space-y-4">
 						{[...Array(4)].map((_, i) => (

--- a/src/components/wallet/__tests__/WalletDetail.responsive.test.tsx
+++ b/src/components/wallet/__tests__/WalletDetail.responsive.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WalletDetail } from "@/components/wallet/WalletDetail";
+import type { WalletBalanceState } from "@/hooks/useWalletBalance";
+
+vi.mock("@/hooks/useWalletBalance", () => ({
+	useWalletBalance: vi.fn(),
+}));
+
+Object.assign(navigator, {
+	clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+});
+
+import { useWalletBalance } from "@/hooks/useWalletBalance";
+
+const baseState: WalletBalanceState = {
+	wallet: {
+		id: "wallet-001",
+		address: "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI",
+		network: "mainnet",
+		status: "active",
+		createdAt: new Date("2024-01-15T10:30:00Z"),
+		balance: "1250.50 XLM",
+	},
+	balance: "1250.50 XLM",
+	loading: false,
+	error: null,
+	lastUpdated: new Date("2024-01-20T14:22:00Z"),
+	refresh: vi.fn(),
+};
+
+describe("WalletDetail responsive layout", () => {
+	beforeEach(() => {
+		vi.mocked(useWalletBalance).mockReturnValue(baseState);
+	});
+
+	it("renders balance card with responsive padding classes", () => {
+		const { container } = render(<WalletDetail id="wallet-001" />);
+		const cards = container.querySelectorAll(".rounded-xl.border");
+		expect(cards.length).toBeGreaterThanOrEqual(1);
+		const balanceCard = cards[0];
+		expect(balanceCard.className).toContain("p-4");
+		expect(balanceCard.className).toContain("sm:p-6");
+	});
+
+	it("renders wallet info card with responsive padding classes", () => {
+		const { container } = render(<WalletDetail id="wallet-001" />);
+		const cards = container.querySelectorAll(".rounded-xl.border");
+		expect(cards.length).toBeGreaterThanOrEqual(2);
+		const infoCard = cards[1];
+		expect(infoCard.className).toContain("p-4");
+		expect(infoCard.className).toContain("sm:p-6");
+	});
+
+	it("renders dl rows with responsive flex direction", () => {
+		const { container } = render(<WalletDetail id="wallet-001" />);
+		const dlRows = container.querySelectorAll("dl > div");
+		expect(dlRows.length).toBeGreaterThan(0);
+		for (const row of dlRows) {
+			expect(row.className).toContain("flex-col");
+			expect(row.className).toContain("sm:flex-row");
+		}
+	});
+
+	it("renders balance text with responsive size classes", () => {
+		const { container } = render(<WalletDetail id="wallet-001" />);
+		const balanceText = screen.getByText("1250.50 XLM");
+		expect(balanceText.className).toContain("text-3xl");
+		expect(balanceText.className).toContain("sm:text-4xl");
+	});
+
+	it("renders address code with min-w-0 and truncate classes for overflow safety", () => {
+		const { container } = render(<WalletDetail id="wallet-001" />);
+		const addressCode = container.querySelector("code");
+		expect(addressCode).toBeInTheDocument();
+		expect(addressCode?.className).toContain("min-w-0");
+		expect(addressCode?.className).toContain("truncate");
+	});
+
+	it("renders space-y-4 with sm:space-y-6 for responsive vertical spacing", () => {
+		const { container } = render(<WalletDetail id="wallet-001" />);
+		const outerDiv = container.firstChild as HTMLElement;
+		expect(outerDiv.className).toContain("space-y-4");
+		expect(outerDiv.className).toContain("sm:space-y-6");
+	});
+
+	it("renders skeleton with responsive size when loading without balance", () => {
+		vi.mocked(useWalletBalance).mockReturnValue({
+			...baseState,
+			loading: true,
+			balance: null,
+			wallet: null,
+		});
+		const { container } = render(<WalletDetail id="wallet-001" />);
+		const skeleton = container.querySelector(
+			".animate-pulse, [class*='skeleton'], [class*='h-10']",
+		);
+		expect(skeleton).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
Stack DL rows on mobile, add responsive padding/spacing to Balance and Wallet Info cards, shrink balance text on xs, truncate address code block safely, and stack the page header on narrow viewports.

closes #239 