### PR TITLE
feat(wallet-detail): add keyboard navigation (#240)

### DIFF
--- a/src/app/wallet/page.tsx
+++ b/src/app/wallet/page.tsx
@@ -43,6 +43,13 @@ function WalletPageContent() {
 
 	return (
 		<div className="min-h-screen bg-neutral-50 text-neutral-900 font-sans p-6 md:p-12">
+			{/* Skip link for keyboard users */}
+			<a
+				href="#main-content"
+				className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-neutral-900 focus:shadow-lg focus:ring-2 focus:ring-blue-500"
+			>
+				Skip to main content
+			</a>
 			<div className="max-w-4xl mx-auto space-y-8">
 				<header className="flex items-center justify-between mb-8">
 					<div>
@@ -60,7 +67,7 @@ function WalletPageContent() {
 					<div className="flex gap-3">
 						<Link
 							href="/"
-							className="px-4 py-2 text-sm font-medium text-neutral-600 bg-white border border-neutral-200 rounded-lg shadow-xs hover:bg-neutral-50 transition-colors"
+							className="px-4 py-2 text-sm font-medium text-neutral-600 bg-white border border-neutral-200 rounded-lg shadow-xs hover:bg-neutral-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
 						>
 							Back to Dashboard
 						</Link>
@@ -93,7 +100,11 @@ function WalletPageContent() {
 				)}
 
 				{!loading && wallet && (
-					<section className="rounded-2xl border border-neutral-200 bg-white p-8 shadow-sm space-y-6">
+					<section
+						id="main-content"
+						aria-label="Wallet information"
+						className="rounded-2xl border border-neutral-200 bg-white p-8 shadow-sm space-y-6"
+					>
 						<dl className="grid gap-6 sm:grid-cols-2">
 							<div>
 								<dt className="text-sm font-medium text-neutral-500">

--- a/src/components/wallet/WalletDetail.tsx
+++ b/src/components/wallet/WalletDetail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Check, Copy, RefreshCw } from "lucide-react";
+import { useId } from "react";
 import { Button } from "@/components/ui/button";
 import { ErrorState } from "@/components/ui/ErrorState";
 import { Skeleton } from "@/components/ui/Skeleton";
@@ -19,6 +20,8 @@ export function WalletDetail({ id }: WalletDetailProps) {
 	const { wallet, balance, loading, error, lastUpdated, refresh } =
 		useWalletBalance(id);
 	const { copy, copied } = useCopyToClipboard();
+	const balanceHeadingId = useId();
+	const infoHeadingId = useId();
 
 	if (error && !wallet) {
 		return (
@@ -32,9 +35,15 @@ export function WalletDetail({ id }: WalletDetailProps) {
 	return (
 		<div className="space-y-6">
 			{/* Balance card */}
-			<div className="rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+			<section
+				aria-labelledby={balanceHeadingId}
+				className="rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900"
+			>
 				<div className="mb-4 flex items-center justify-between">
-					<h2 className="text-sm font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+					<h2
+						id={balanceHeadingId}
+						className="text-sm font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400"
+					>
 						Live Balance
 					</h2>
 					<div className="flex items-center gap-2">
@@ -48,32 +57,49 @@ export function WalletDetail({ id }: WalletDetailProps) {
 							onClick={refresh}
 							disabled={loading}
 							aria-label="Refresh balance"
-							className="rounded-md p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600 disabled:opacity-50 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+							aria-busy={loading}
+							className="rounded-md p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 dark:hover:bg-zinc-800 dark:hover:text-zinc-300 dark:focus-visible:ring-blue-400"
 						>
 							<RefreshCw
 								className={`h-4 w-4 ${loading ? "animate-spin" : ""}`}
+								aria-hidden="true"
 							/>
 						</button>
 					</div>
 				</div>
 
 				{loading && !balance ? (
-					<Skeleton className="h-12 w-48" />
+					<Skeleton className="h-12 w-48" aria-label="Loading balance" />
 				) : (
-					<p className="text-4xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
+					<p
+						aria-live="polite"
+						aria-atomic="true"
+						className="text-4xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50"
+					>
 						{balance ?? "—"}
 					</p>
 				)}
 
 				{error && wallet && (
-					<p className="mt-2 text-sm text-red-600 dark:text-red-400">{error}</p>
+					<p
+						role="alert"
+						className="mt-2 text-sm text-red-600 dark:text-red-400"
+					>
+						{error}
+					</p>
 				)}
-			</div>
+			</section>
 
 			{/* Wallet metadata */}
 			{wallet ? (
-				<div className="rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-					<h2 className="mb-4 text-sm font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+				<section
+					aria-labelledby={infoHeadingId}
+					className="rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900"
+				>
+					<h2
+						id={infoHeadingId}
+						className="mb-4 text-sm font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400"
+					>
 						Wallet Info
 					</h2>
 					<dl className="space-y-4">
@@ -89,12 +115,15 @@ export function WalletDetail({ id }: WalletDetailProps) {
 									variant="ghost"
 									size="icon-sm"
 									onClick={() => copy(wallet.address)}
+									aria-label={
+										copied ? "Address copied" : "Copy wallet address"
+									}
 									title={copied ? "Copied!" : "Copy address"}
 								>
 									{copied ? (
-										<Check className="h-4 w-4 text-green-500" />
+										<Check className="h-4 w-4 text-green-500" aria-hidden="true" />
 									) : (
-										<Copy className="h-4 w-4" />
+										<Copy className="h-4 w-4" aria-hidden="true" />
 									)}
 								</Button>
 							</dd>
@@ -134,7 +163,7 @@ export function WalletDetail({ id }: WalletDetailProps) {
 							</div>
 						)}
 					</dl>
-				</div>
+				</section>
 			) : (
 				<div className="rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
 					<Skeleton className="mb-4 h-4 w-24" />

--- a/src/components/wallet/__tests__/WalletDetail.keyboard.test.tsx
+++ b/src/components/wallet/__tests__/WalletDetail.keyboard.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { WalletDetail } from "@/components/wallet/WalletDetail";
+import type { WalletBalanceState } from "@/hooks/useWalletBalance";
+
+vi.mock("@/hooks/useWalletBalance", () => ({
+	useWalletBalance: vi.fn(),
+}));
+
+Object.assign(navigator, {
+	clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+});
+
+import { useWalletBalance } from "@/hooks/useWalletBalance";
+
+const mockRefresh = vi.fn();
+
+const baseState: WalletBalanceState = {
+	wallet: {
+		id: "wallet-001",
+		address: "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI",
+		network: "mainnet",
+		status: "active",
+		createdAt: new Date("2024-01-15T10:30:00Z"),
+		balance: "1250.50 XLM",
+	},
+	balance: "1250.50 XLM",
+	loading: false,
+	error: null,
+	lastUpdated: new Date("2024-01-20T14:22:00Z"),
+	refresh: mockRefresh,
+};
+
+describe("WalletDetail keyboard navigation", () => {
+	beforeEach(() => {
+		vi.mocked(useWalletBalance).mockReturnValue(baseState);
+		mockRefresh.mockClear();
+	});
+
+	it("sections have aria-labelledby pointing to headings", () => {
+		render(<WalletDetail id="wallet-001" />);
+		const sections = document.querySelectorAll("section[aria-labelledby]");
+		expect(sections.length).toBeGreaterThanOrEqual(2);
+		for (const section of sections) {
+			const headingId = section.getAttribute("aria-labelledby");
+			expect(headingId).toBeTruthy();
+			const heading = document.getElementById(headingId as string);
+			expect(heading).toBeInTheDocument();
+		}
+	});
+
+	it("refresh button is keyboard focusable and activatable", async () => {
+		const user = userEvent.setup();
+		render(<WalletDetail id="wallet-001" />);
+
+		const refreshBtn = screen.getByRole("button", { name: /refresh balance/i });
+		refreshBtn.focus();
+		expect(refreshBtn).toHaveFocus();
+
+		await user.keyboard("{Enter}");
+		expect(mockRefresh).toHaveBeenCalledOnce();
+	});
+
+	it("refresh button has focus-visible ring classes", () => {
+		render(<WalletDetail id="wallet-001" />);
+		const refreshBtn = screen.getByRole("button", { name: /refresh balance/i });
+		expect(refreshBtn.className).toContain("focus-visible:ring-2");
+		expect(refreshBtn.className).toContain("focus-visible:ring-blue-500");
+	});
+
+	it("refresh button has aria-busy when loading", () => {
+		vi.mocked(useWalletBalance).mockReturnValue({
+			...baseState,
+			loading: true,
+		});
+		render(<WalletDetail id="wallet-001" />);
+		const refreshBtn = screen.getByRole("button", { name: /refresh balance/i });
+		expect(refreshBtn).toHaveAttribute("aria-busy", "true");
+	});
+
+	it("copy button has descriptive aria-label", () => {
+		render(<WalletDetail id="wallet-001" />);
+		const copyBtn = screen.getByRole("button", { name: /copy wallet address/i });
+		expect(copyBtn).toBeInTheDocument();
+	});
+
+	it("copy button is keyboard focusable and activatable", async () => {
+		const user = userEvent.setup();
+		render(<WalletDetail id="wallet-001" />);
+
+		const copyBtn = screen.getByRole("button", { name: /copy wallet address/i });
+		copyBtn.focus();
+		expect(copyBtn).toHaveFocus();
+
+		await user.keyboard("{Enter}");
+		// After activation, the button label should change to "Address copied"
+		expect(
+			screen.getByRole("button", { name: /address copied/i }),
+		).toBeInTheDocument();
+	});
+
+	it("balance text has aria-live polite for screen reader updates", () => {
+		render(<WalletDetail id="wallet-001" />);
+		const balancePara = screen.getByText("1250.50 XLM");
+		expect(balancePara).toHaveAttribute("aria-live", "polite");
+		expect(balancePara).toHaveAttribute("aria-atomic", "true");
+	});
+
+	it("inline error has role=alert for screen readers", () => {
+		vi.mocked(useWalletBalance).mockReturnValue({
+			...baseState,
+			error: "Network error",
+		});
+		render(<WalletDetail id="wallet-001" />);
+		const alert = screen.getByRole("alert");
+		expect(alert).toHaveTextContent("Network error");
+	});
+
+	it("tab sequence reaches refresh then copy button", async () => {
+		const user = userEvent.setup();
+		render(<WalletDetail id="wallet-001" />);
+
+		await user.tab();
+		const focused = document.activeElement;
+		expect(focused).toBeTruthy();
+		const isInteractive =
+			focused?.tagName === "BUTTON" || focused?.getAttribute("role") === "button";
+		expect(isInteractive).toBe(true);
+	});
+});


### PR DESCRIPTION
Wrap Balance and Wallet Info cards in <section> with aria-labelledby, add aria-live/aria-atomic to balance, aria-busy to refresh button, descriptive aria-labels to copy button, role=alert for inline errors, and a skip-link for keyboard users on the wallet page.

closes #240 
