### PR TITLE
feat(wallet-detail): add copy-to-clipboard UX (#241)

### DIFF
--- a/src/app/wallet/page.tsx
+++ b/src/app/wallet/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { AlertCircle, Check, Copy } from "lucide-react";
 import Link from "next/link";
 import { Suspense, useEffect, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import TransactionsTable from "@/components/TransactionsTable/TransactionsTable";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { ErrorState } from "@/components/ui/ErrorState";
@@ -10,11 +12,11 @@ import { Skeleton } from "@/components/ui/Skeleton";
 import { NetworkBadge } from "@/components/wallet/NetworkBadge";
 import ReceiveWalletModal from "@/components/wallet/ReceiveWalletModal";
 import { StatusIndicator } from "@/components/wallet/StatusIndicator";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { useWallets } from "@/hooks/useWallets";
 import { isValidStellarAddress } from "@/utils/addressValidation";
 import { formatDate } from "@/utils/dateFormatting";
 import { isWalletFunded } from "@/utils/walletUtils";
-import TransactionsTable from "@/components/TransactionsTable/TransactionsTable";
 
 function WalletPageContent() {
 	const { wallets, loading, error, refetch } = useWallets();
@@ -22,6 +24,7 @@ function WalletPageContent() {
 	const router = useRouter();
 	const searchParams = useSearchParams();
 	const [isReceiveOpen, setIsReceiveOpen] = useState(false);
+	const { copy, copied, error: copyError } = useCopyToClipboard();
 
 	const wallet = wallets?.[0] ?? null;
 	const canReceive = !!wallet && isValidStellarAddress(wallet.address.trim());
@@ -140,9 +143,53 @@ function WalletPageContent() {
 									Address
 								</dt>
 								<dd className="mt-1">
-									<code className="break-all rounded bg-neutral-100 px-2 py-1 font-mono text-sm text-neutral-700">
-										{wallet.address}
-									</code>
+									<div className="flex items-start gap-2 rounded-lg border border-neutral-200 bg-neutral-100 px-3 py-2">
+										<code className="min-w-0 flex-1 break-all font-mono text-sm text-neutral-700">
+											{wallet.address}
+										</code>
+										<Button
+											variant="ghost"
+											size="icon-sm"
+											onClick={() => copy(wallet.address, wallet.address)}
+											aria-label={
+												copyError
+													? copyError
+													: copied
+														? "Address copied"
+														: "Copy wallet address"
+											}
+											title={
+												copyError
+													? copyError
+													: copied
+														? "Copied!"
+														: "Copy address"
+											}
+											className="shrink-0 text-neutral-500 hover:text-neutral-700"
+										>
+											{copyError ? (
+												<AlertCircle
+													className="h-4 w-4 text-red-500"
+													aria-hidden="true"
+												/>
+											) : copied ? (
+												<Check
+													className="h-4 w-4 text-green-600"
+													aria-hidden="true"
+												/>
+											) : (
+												<Copy className="h-4 w-4" aria-hidden="true" />
+											)}
+										</Button>
+									</div>
+									{copyError && (
+										<p
+											role="alert"
+											className="mt-1 text-xs text-red-600"
+										>
+											{copyError}
+										</p>
+									)}
 								</dd>
 							</div>
 						</dl>

--- a/src/components/wallet/WalletDetail.tsx
+++ b/src/components/wallet/WalletDetail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, Copy, RefreshCw } from "lucide-react";
+import { AlertCircle, Check, Copy, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ErrorState } from "@/components/ui/ErrorState";
 import { Skeleton } from "@/components/ui/Skeleton";
@@ -18,7 +18,7 @@ interface WalletDetailProps {
 export function WalletDetail({ id }: WalletDetailProps) {
 	const { wallet, balance, loading, error, lastUpdated, refresh } =
 		useWalletBalance(id);
-	const { copy, copied } = useCopyToClipboard();
+	const { copy, copied, error: copyError } = useCopyToClipboard();
 
 	if (error && !wallet) {
 		return (
@@ -81,22 +81,54 @@ export function WalletDetail({ id }: WalletDetailProps) {
 							<dt className="text-sm text-zinc-500 dark:text-zinc-400">
 								Address
 							</dt>
-							<dd className="flex items-center gap-2">
-								<code className="rounded bg-zinc-100 px-2 py-1 font-mono text-sm text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
-									{truncateAddress(wallet.address)}
-								</code>
-								<Button
-									variant="ghost"
-									size="icon-sm"
-									onClick={() => copy(wallet.address)}
-									title={copied ? "Copied!" : "Copy address"}
-								>
-									{copied ? (
-										<Check className="h-4 w-4 text-green-500" />
-									) : (
-										<Copy className="h-4 w-4" />
-									)}
-								</Button>
+							<dd className="flex flex-col items-end gap-1">
+								<div className="flex items-center gap-2">
+									<code className="rounded bg-zinc-100 px-2 py-1 font-mono text-sm text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
+										{truncateAddress(wallet.address)}
+									</code>
+									<Button
+										variant="ghost"
+										size="icon-sm"
+										onClick={() => copy(wallet.address)}
+										aria-label={
+											copyError
+												? copyError
+												: copied
+													? "Address copied"
+													: "Copy wallet address"
+										}
+										title={
+											copyError
+												? copyError
+												: copied
+													? "Copied!"
+													: "Copy address"
+										}
+										disabled={!!copyError}
+									>
+										{copyError ? (
+											<AlertCircle
+												className="h-4 w-4 text-red-500"
+												aria-hidden="true"
+											/>
+										) : copied ? (
+											<Check
+												className="h-4 w-4 text-green-500"
+												aria-hidden="true"
+											/>
+										) : (
+											<Copy className="h-4 w-4" aria-hidden="true" />
+										)}
+									</Button>
+								</div>
+								{copyError && (
+									<p
+										role="alert"
+										className="text-xs text-red-600 dark:text-red-400"
+									>
+										{copyError}
+									</p>
+								)}
 							</dd>
 						</div>
 						<div className="flex items-center justify-between">

--- a/src/components/wallet/__tests__/WalletDetail.clipboard.test.tsx
+++ b/src/components/wallet/__tests__/WalletDetail.clipboard.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { WalletDetail } from "@/components/wallet/WalletDetail";
+import type { WalletBalanceState } from "@/hooks/useWalletBalance";
+
+vi.mock("@/hooks/useWalletBalance", () => ({
+	useWalletBalance: vi.fn(),
+}));
+
+// Mock the underlying copy utility so we can control success/failure
+vi.mock("@/utils/copyToClipboard", () => ({
+	copyToClipboard: vi.fn(),
+}));
+
+import { useWalletBalance } from "@/hooks/useWalletBalance";
+import { copyToClipboard } from "@/utils/copyToClipboard";
+
+const WALLET_ADDRESS =
+	"GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI";
+
+const baseState: WalletBalanceState = {
+	wallet: {
+		id: "wallet-001",
+		address: WALLET_ADDRESS,
+		network: "mainnet",
+		status: "active",
+		createdAt: new Date("2024-01-15T10:30:00Z"),
+		balance: "1250.50 XLM",
+	},
+	balance: "1250.50 XLM",
+	loading: false,
+	error: null,
+	lastUpdated: new Date("2024-01-20T14:22:00Z"),
+	refresh: vi.fn(),
+};
+
+beforeEach(() => {
+	vi.mocked(useWalletBalance).mockReturnValue(baseState);
+	vi.mocked(copyToClipboard).mockResolvedValue(undefined);
+});
+
+describe("WalletDetail copy-to-clipboard UX", () => {
+	it("renders copy button for the wallet address", () => {
+		render(<WalletDetail id="wallet-001" />);
+		expect(
+			screen.getByRole("button", { name: /copy wallet address/i }),
+		).toBeInTheDocument();
+	});
+
+	it("copy button shows Copy icon initially", () => {
+		render(<WalletDetail id="wallet-001" />);
+		const copyBtn = screen.getByRole("button", { name: /copy wallet address/i });
+		const svg = copyBtn.querySelector("svg");
+		expect(svg).toBeInTheDocument();
+	});
+
+	it("copies the full address (not truncated) on click", async () => {
+		const user = userEvent.setup();
+		render(<WalletDetail id="wallet-001" />);
+
+		await user.click(
+			screen.getByRole("button", { name: /copy wallet address/i }),
+		);
+
+		expect(copyToClipboard).toHaveBeenCalledWith(WALLET_ADDRESS);
+	});
+
+	it("changes aria-label to 'Address copied' after successful copy", async () => {
+		const user = userEvent.setup();
+		render(<WalletDetail id="wallet-001" />);
+
+		await user.click(
+			screen.getByRole("button", { name: /copy wallet address/i }),
+		);
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", { name: /address copied/i }),
+			).toBeInTheDocument();
+		});
+	});
+
+	it("shows error state when clipboard write fails", async () => {
+		vi.mocked(copyToClipboard).mockRejectedValue(
+			new Error("Clipboard denied"),
+		);
+		const user = userEvent.setup();
+		render(<WalletDetail id="wallet-001" />);
+
+		await user.click(
+			screen.getByRole("button", { name: /copy wallet address/i }),
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole("alert")).toBeInTheDocument();
+		});
+	});
+
+	it("disables copy button when there is a clipboard error", async () => {
+		vi.mocked(copyToClipboard).mockRejectedValue(
+			new Error("Permission denied"),
+		);
+		const user = userEvent.setup();
+		render(<WalletDetail id="wallet-001" />);
+
+		await user.click(
+			screen.getByRole("button", { name: /copy wallet address/i }),
+		);
+
+		await waitFor(() => {
+			const btn = screen.getByRole("button", { name: /permission denied/i });
+			expect(btn).toBeDisabled();
+		});
+	});
+
+	it("does not render copy button when wallet is not loaded", () => {
+		vi.mocked(useWalletBalance).mockReturnValue({
+			...baseState,
+			wallet: null,
+			balance: null,
+		});
+		render(<WalletDetail id="wallet-001" />);
+		expect(
+			screen.queryByRole("button", { name: /copy wallet address/i }),
+		).not.toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
Add copy button with error/success states to the address row in both WalletDetail and the wallet page. WalletDetail now surfaces clipboard errors via role=alert and disables the button on failure; wallet page gets an inline copy button wrapping the full address code block.

closes #241 