### PR TITLE
feat: #291-294 analytics dark mode, mobile polish, tracking stub, component tests

### DIFF
--- a/src/app/dashboard/analytics/page.tsx
+++ b/src/app/dashboard/analytics/page.tsx
@@ -11,6 +11,7 @@ import { MetricsCards } from "@/components/analytics/MetricsCards";
 import { TopAssetsTable } from "@/components/analytics/TopAssetsTable";
 import { ErrorState } from "@/components/ui/ErrorState";
 import { useAnalytics } from "@/hooks/useAnalytics";
+import { useAnalyticsTracking } from "@/hooks/useAnalyticsTracking";
 
 export default function AnalyticsPage() {
 	const [range, setRange] = useState<DateRange>(() => {
@@ -23,6 +24,12 @@ export default function AnalyticsPage() {
 		};
 	});
 	const { data, isLoading, isError, error, refetch } = useAnalytics();
+	const { track } = useAnalyticsTracking("analytics");
+
+	function handleRangeChange(newRange: DateRange) {
+		setRange(newRange);
+		track("date_range_changed", { from: newRange.from, to: newRange.to });
+	}
 
 	if (isLoading) {
 		return <AnalyticsLoadingSkeleton />;
@@ -40,7 +47,7 @@ export default function AnalyticsPage() {
 
 	return (
 		<div className="space-y-6">
-			<AnalyticsHeader range={range} onRangeChange={setRange} />
+			<AnalyticsHeader range={range} onRangeChange={handleRangeChange} />
 
 			<MetricsCards metrics={data.metrics} />
 

--- a/src/components/analytics/AnalyticsLoadingSkeleton.tsx
+++ b/src/components/analytics/AnalyticsLoadingSkeleton.tsx
@@ -81,7 +81,7 @@ export function TopAssetsTableSkeleton({ rows = 5 }: { rows?: number }) {
 			aria-busy="true"
 		>
 			{/* header */}
-			<div className="border-b border-zinc-200 px-6 py-4 dark:border-zinc-800 space-y-2">
+			<div className="border-b border-zinc-200 px-4 py-4 sm:px-6 dark:border-zinc-800 space-y-2">
 				<Skeleton className="h-5 w-44" />
 				<Skeleton className="h-4 w-56" />
 			</div>
@@ -90,12 +90,12 @@ export function TopAssetsTableSkeleton({ rows = 5 }: { rows?: number }) {
 			<div className="divide-y divide-zinc-100 dark:divide-zinc-800">
 				{Array.from({ length: rows }).map((_, i) => (
 					// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
-					<div key={i} className="flex items-center gap-4 px-6 py-4">
+					<div key={i} className="flex items-center gap-4 px-4 py-4 sm:px-6">
 						{/* rank */}
 						<Skeleton className="h-4 w-4 shrink-0" />
 						{/* avatar + name */}
 						<div className="flex items-center gap-3 flex-1 min-w-0">
-							<Skeleton className="h-8 w-8 rounded-full shrink-0" />
+							<Skeleton className="h-7 w-7 rounded-full shrink-0 sm:h-8 sm:w-8" />
 							<div className="space-y-1 min-w-0">
 								<Skeleton className="h-4 w-24" />
 								<Skeleton className="h-3 w-10" />
@@ -103,12 +103,12 @@ export function TopAssetsTableSkeleton({ rows = 5 }: { rows?: number }) {
 						</div>
 						{/* volume */}
 						<Skeleton className="h-4 w-20 ml-auto" />
-						{/* change */}
-						<Skeleton className="h-4 w-12" />
-						{/* tvl */}
-						<Skeleton className="h-4 w-16" />
-						{/* tx count */}
-						<Skeleton className="h-4 w-14" />
+						{/* change — hidden on xs */}
+						<Skeleton className="hidden h-4 w-12 sm:block" />
+						{/* tvl — hidden below md */}
+						<Skeleton className="hidden h-4 w-16 md:block" />
+						{/* tx count — hidden below md */}
+						<Skeleton className="hidden h-4 w-14 md:block" />
 					</div>
 				))}
 			</div>

--- a/src/components/analytics/TopAssetsTable.tsx
+++ b/src/components/analytics/TopAssetsTable.tsx
@@ -7,8 +7,8 @@ interface TopAssetsTableProps {
 export function TopAssetsTable({ assets }: TopAssetsTableProps) {
 	return (
 		<div className="rounded-xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-			<div className="border-b border-zinc-200 px-6 py-4 dark:border-zinc-800">
-				<h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+			<div className="border-b border-zinc-200 px-4 py-4 sm:px-6 dark:border-zinc-800">
+				<h3 className="text-base font-semibold text-zinc-900 sm:text-lg dark:text-zinc-50">
 					Top Assets by Volume
 				</h3>
 				<p className="mt-0.5 text-sm text-zinc-500 dark:text-zinc-400">
@@ -17,25 +17,25 @@ export function TopAssetsTable({ assets }: TopAssetsTableProps) {
 			</div>
 
 			<div className="overflow-x-auto">
-				<table className="w-full text-sm">
+				<table className="w-full min-w-[480px] text-sm">
 					<thead>
 						<tr className="border-b border-zinc-100 dark:border-zinc-800">
-							<th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+							<th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-zinc-500 sm:px-6 dark:text-zinc-400">
 								#
 							</th>
-							<th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+							<th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-zinc-500 sm:px-6 dark:text-zinc-400">
 								Asset
 							</th>
-							<th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+							<th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-zinc-500 sm:px-6 dark:text-zinc-400">
 								Volume
 							</th>
-							<th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+							<th className="hidden px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-zinc-500 sm:table-cell sm:px-6 dark:text-zinc-400">
 								Change
 							</th>
-							<th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+							<th className="hidden px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-zinc-500 md:table-cell md:px-6 dark:text-zinc-400">
 								TVL
 							</th>
-							<th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+							<th className="hidden px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-zinc-500 md:table-cell md:px-6 dark:text-zinc-400">
 								Transactions
 							</th>
 						</tr>
@@ -46,16 +46,16 @@ export function TopAssetsTable({ assets }: TopAssetsTableProps) {
 								key={asset.rank}
 								className="transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
 							>
-								<td className="px-6 py-4 text-zinc-500 dark:text-zinc-400">
+								<td className="px-4 py-4 text-zinc-500 sm:px-6 dark:text-zinc-400">
 									{asset.rank}
 								</td>
-								<td className="px-6 py-4">
-									<div className="flex items-center gap-3">
-										<div className="flex h-8 w-8 items-center justify-center rounded-full bg-blue-100 text-xs font-bold text-blue-700 dark:bg-blue-900/50 dark:text-blue-300">
+								<td className="px-4 py-4 sm:px-6">
+									<div className="flex items-center gap-2 sm:gap-3">
+										<div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-blue-100 text-xs font-bold text-blue-700 sm:h-8 sm:w-8 dark:bg-blue-900/50 dark:text-blue-300">
 											{asset.symbol.charAt(0)}
 										</div>
-										<div>
-											<p className="font-medium text-zinc-900 dark:text-zinc-50">
+										<div className="min-w-0">
+											<p className="truncate font-medium text-zinc-900 dark:text-zinc-50">
 												{asset.name}
 											</p>
 											<p className="text-xs text-zinc-500 dark:text-zinc-400">
@@ -64,10 +64,10 @@ export function TopAssetsTable({ assets }: TopAssetsTableProps) {
 										</div>
 									</div>
 								</td>
-								<td className="px-6 py-4 text-right font-medium text-zinc-900 dark:text-zinc-50">
+								<td className="px-4 py-4 text-right font-medium text-zinc-900 sm:px-6 dark:text-zinc-50">
 									{asset.volume}
 								</td>
-								<td className="px-6 py-4 text-right">
+								<td className="hidden px-4 py-4 text-right sm:table-cell sm:px-6">
 									<span
 										className={`inline-flex items-center gap-0.5 text-sm font-medium ${
 											asset.volumeChange >= 0
@@ -99,10 +99,10 @@ export function TopAssetsTable({ assets }: TopAssetsTableProps) {
 										{Math.abs(asset.volumeChange)}%
 									</span>
 								</td>
-								<td className="px-6 py-4 text-right text-zinc-900 dark:text-zinc-50">
+								<td className="hidden px-4 py-4 text-right text-zinc-900 md:table-cell md:px-6 dark:text-zinc-50">
 									{asset.tvl}
 								</td>
-								<td className="px-6 py-4 text-right text-zinc-900 dark:text-zinc-50">
+								<td className="hidden px-4 py-4 text-right text-zinc-900 md:table-cell md:px-6 dark:text-zinc-50">
 									{asset.txCount.toLocaleString()}
 								</td>
 							</tr>

--- a/src/components/analytics/TransactionVolumeChart.tsx
+++ b/src/components/analytics/TransactionVolumeChart.tsx
@@ -79,6 +79,13 @@ export function TransactionVolumeChart({ data, metric = "count" }: Props) {
 		setTooltip({ x: nearest.x, y: nearest.y, point: nearest.d });
 	}
 
+	// Resolve CSS variable values for SVG (SVG doesn't inherit Tailwind dark: variants)
+	const isDark =
+		typeof window !== "undefined" &&
+		document.documentElement.classList.contains("dark");
+	const gridColor = isDark ? "oklch(1 0 0 / 10%)" : "#e4e4e7";
+	const axisColor = isDark ? "#a1a1aa" : "#71717a";
+
 	return (
 		<div className="relative w-full">
 			<svg
@@ -106,7 +113,7 @@ export function TransactionVolumeChart({ data, metric = "count" }: Props) {
 						x2={W - PADDING.right}
 						y1={t.y}
 						y2={t.y}
-						stroke="#e4e4e7"
+						stroke={gridColor}
 						strokeWidth="1"
 					/>
 				))}
@@ -132,7 +139,7 @@ export function TransactionVolumeChart({ data, metric = "count" }: Props) {
 						y={t.y + 4}
 						textAnchor="end"
 						fontSize="11"
-						fill="#71717a"
+						fill={axisColor}
 					>
 						{t.label}
 					</text>
@@ -146,7 +153,7 @@ export function TransactionVolumeChart({ data, metric = "count" }: Props) {
 						y={HEIGHT - 8}
 						textAnchor="middle"
 						fontSize="11"
-						fill="#71717a"
+						fill={axisColor}
 					>
 						{t.label}
 					</text>

--- a/src/components/layouts/DashboardLayout.tsx
+++ b/src/components/layouts/DashboardLayout.tsx
@@ -84,7 +84,7 @@ function DashboardLayoutShell({ children }: DashboardLayoutProps) {
 	return (
 		<NetworkProvider>
 			<div
-				className="relative flex min-h-screen bg-gray-50"
+				className="relative flex min-h-screen bg-gray-50 dark:bg-zinc-950"
 				onKeyDown={handleKeyDown}
 				onTouchStart={handleTouchStart}
 				onTouchEnd={handleTouchEnd}

--- a/src/components/layouts/TopNav.tsx
+++ b/src/components/layouts/TopNav.tsx
@@ -5,11 +5,14 @@ import {
 	BellIcon,
 	ChevronDownIcon,
 	MagnifyingGlassIcon,
+	MoonIcon,
+	SunIcon,
 } from "@heroicons/react/24/outline";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useAuth } from "@/context/AuthContext";
 import { useNetwork } from "@/context/NetworkContext";
+import { useDarkMode } from "@/hooks/useDarkMode";
 
 interface TopNavProps {
 	onMenuClick: () => void;
@@ -26,6 +29,7 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 	const pathname = usePathname();
 	const { network, setNetwork } = useNetwork();
 	const { user, isLoading } = useAuth();
+	const { isDark, toggle: toggleDark } = useDarkMode();
 
 	// Get current page title from pathname
 	const pageTitle = (() => {
@@ -55,7 +59,7 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 	}, [pageTitle, network]);
 
 	return (
-		<header className="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b border-gray-200 bg-white/95 px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:px-8 backdrop-blur supports-backdrop-filter:bg-white/60">
+		<header className="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b border-gray-200 bg-white/95 px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:px-8 backdrop-blur supports-backdrop-filter:bg-white/60 dark:border-zinc-800 dark:bg-zinc-900/95 dark:supports-backdrop-filter:bg-zinc-900/60">
 			{/* Menu button for mobile */}
 			<button
 				type="button"
@@ -157,6 +161,20 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 					>
 						<span className="sr-only">Search</span>
 						<MagnifyingGlassIcon className="h-5 w-5" aria-hidden="true" />
+					</button>
+
+					{/* Dark mode toggle */}
+					<button
+						type="button"
+						onClick={toggleDark}
+						aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+						className="rounded-full p-1 text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:text-zinc-400 dark:hover:text-zinc-300"
+					>
+						{isDark ? (
+							<SunIcon className="h-5 w-5" aria-hidden="true" />
+						) : (
+							<MoonIcon className="h-5 w-5" aria-hidden="true" />
+						)}
 					</button>
 
 					{/* Notifications */}

--- a/src/components/wallet/__tests__/NetworkBadge.test.tsx
+++ b/src/components/wallet/__tests__/NetworkBadge.test.tsx
@@ -195,4 +195,19 @@ describe("NetworkBadge", () => {
 			expect(badge).toHaveClass("rounded-full");
 		});
 	});
+
+	describe("Invalid / unknown network values", () => {
+		it("defaults to mainnet label for unrecognised network value", () => {
+			// Cast to bypass TS since real-world data may be untrusted
+			render(<NetworkBadge network={"unknown" as never} />);
+			expect(screen.getByText("Mainnet")).toBeInTheDocument();
+		});
+
+		it("defaults to mainnet styles for unrecognised network value", () => {
+			const { container } = render(<NetworkBadge network={"" as never} />);
+			const badge = container.querySelector("span");
+			expect(badge).toHaveClass("bg-blue-100");
+			expect(badge).toHaveClass("text-blue-800");
+		});
+	});
 });

--- a/src/components/wallet/__tests__/StatusIndicator.test.tsx
+++ b/src/components/wallet/__tests__/StatusIndicator.test.tsx
@@ -241,4 +241,24 @@ describe("StatusIndicator", () => {
 			expect(text).toBeInTheDocument();
 		});
 	});
+
+	describe("Invalid / unknown status values", () => {
+		it("defaults to 'Inactive' label for unrecognised status", () => {
+			render(<StatusIndicator status={"broken" as never} />);
+			expect(screen.getByText("Inactive")).toBeInTheDocument();
+		});
+
+		it("defaults to inactive styles for unrecognised status", () => {
+			const { container } = render(<StatusIndicator status={"" as never} />);
+			const badge = container.querySelector("span");
+			expect(badge).toHaveClass("bg-zinc-100");
+			expect(badge).toHaveClass("text-zinc-600");
+		});
+
+		it("does not show pulse animation for unknown status", () => {
+			const { container } = render(<StatusIndicator status={"broken" as never} />);
+			const dot = container.querySelector(".animate-pulse");
+			expect(dot).not.toBeInTheDocument();
+		});
+	});
 });

--- a/src/hooks/useAnalyticsTracking.test.ts
+++ b/src/hooks/useAnalyticsTracking.test.ts
@@ -1,0 +1,59 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAnalyticsTracking } from "./useAnalyticsTracking";
+
+describe("useAnalyticsTracking", () => {
+	let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		consoleSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		consoleSpy.mockRestore();
+	});
+
+	it("fires a page_view event on mount", () => {
+		renderHook(() => useAnalyticsTracking("analytics"));
+		expect(consoleSpy).toHaveBeenCalledWith(
+			"[analytics]",
+			"page_view",
+			{ page: "analytics" },
+		);
+	});
+
+	it("uses the provided page name in the page_view event", () => {
+		renderHook(() => useAnalyticsTracking("wallets"));
+		expect(consoleSpy).toHaveBeenCalledWith(
+			"[analytics]",
+			"page_view",
+			{ page: "wallets" },
+		);
+	});
+
+	it("track() dispatches the event with properties", () => {
+		const { result } = renderHook(() => useAnalyticsTracking("analytics"));
+		result.current.track("date_range_changed", { from: "2024-01-01", to: "2024-01-07" });
+		expect(consoleSpy).toHaveBeenCalledWith(
+			"[analytics]",
+			"date_range_changed",
+			{ from: "2024-01-01", to: "2024-01-07" },
+		);
+	});
+
+	it("track() dispatches the event with empty object when no properties given", () => {
+		const { result } = renderHook(() => useAnalyticsTracking("analytics"));
+		result.current.track("some_event");
+		expect(consoleSpy).toHaveBeenCalledWith("[analytics]", "some_event", {});
+	});
+
+	it("only fires page_view once per mount", () => {
+		const { rerender } = renderHook(() => useAnalyticsTracking("analytics"));
+		rerender();
+		rerender();
+		const pageViewCalls = consoleSpy.mock.calls.filter(
+			(c) => c[1] === "page_view",
+		);
+		expect(pageViewCalls).toHaveLength(1);
+	});
+});

--- a/src/hooks/useAnalyticsTracking.ts
+++ b/src/hooks/useAnalyticsTracking.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+export interface TrackEventPayload {
+	/** Logical event name, e.g. "date_range_changed" */
+	event: string;
+	/** Optional key-value metadata attached to the event */
+	properties?: Record<string, unknown>;
+}
+
+/**
+ * Stub analytics tracking hook.
+ *
+ * Fires a page-view on mount and exposes a `track` function for custom events.
+ * All events are logged to the console in development and can be swapped for a
+ * real analytics provider (e.g. Segment, PostHog) by replacing the `dispatch`
+ * call below.
+ *
+ * @param pageName - Identifies the page/screen for the automatic page-view event.
+ */
+export function useAnalyticsTracking(pageName: string) {
+	const pageNameRef = useRef(pageName);
+	pageNameRef.current = pageName;
+
+	/** Central dispatch — replace with your real analytics SDK call. */
+	const dispatch = useCallback((payload: TrackEventPayload) => {
+		if (process.env.NODE_ENV !== "production") {
+			// eslint-disable-next-line no-console
+			console.debug("[analytics]", payload.event, payload.properties ?? {});
+		}
+		// TODO: window.analytics?.track(payload.event, payload.properties);
+	}, []);
+
+	// Automatic page-view on mount
+	useEffect(() => {
+		dispatch({ event: "page_view", properties: { page: pageNameRef.current } });
+	}, [dispatch]);
+
+	const track = useCallback(
+		(event: string, properties?: Record<string, unknown>) => {
+			dispatch({ event, properties });
+		},
+		[dispatch],
+	);
+
+	return { track };
+}

--- a/src/hooks/useDarkMode.test.ts
+++ b/src/hooks/useDarkMode.test.ts
@@ -1,0 +1,55 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useDarkMode } from "./useDarkMode";
+
+describe("useDarkMode", () => {
+	beforeEach(() => {
+		document.documentElement.classList.remove("dark");
+		localStorage.removeItem("mux_dark_mode");
+	});
+
+	afterEach(() => {
+		document.documentElement.classList.remove("dark");
+		localStorage.removeItem("mux_dark_mode");
+	});
+
+	it("starts in light mode when no preference is stored", () => {
+		const { result } = renderHook(() => useDarkMode());
+		expect(result.current.isDark).toBe(false);
+	});
+
+	it("starts in dark mode when localStorage has 'true'", () => {
+		localStorage.setItem("mux_dark_mode", "true");
+		const { result } = renderHook(() => useDarkMode());
+		expect(result.current.isDark).toBe(true);
+		expect(document.documentElement.classList.contains("dark")).toBe(true);
+	});
+
+	it("toggle() switches from light to dark", () => {
+		const { result } = renderHook(() => useDarkMode());
+		act(() => result.current.toggle());
+		expect(result.current.isDark).toBe(true);
+		expect(document.documentElement.classList.contains("dark")).toBe(true);
+	});
+
+	it("toggle() switches from dark to light", () => {
+		localStorage.setItem("mux_dark_mode", "true");
+		const { result } = renderHook(() => useDarkMode());
+		act(() => result.current.toggle());
+		expect(result.current.isDark).toBe(false);
+		expect(document.documentElement.classList.contains("dark")).toBe(false);
+	});
+
+	it("toggle() persists dark preference to localStorage", () => {
+		const { result } = renderHook(() => useDarkMode());
+		act(() => result.current.toggle());
+		expect(localStorage.getItem("mux_dark_mode")).toBe("true");
+	});
+
+	it("toggle() persists light preference to localStorage", () => {
+		localStorage.setItem("mux_dark_mode", "true");
+		const { result } = renderHook(() => useDarkMode());
+		act(() => result.current.toggle());
+		expect(localStorage.getItem("mux_dark_mode")).toBe("false");
+	});
+});

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "mux_dark_mode";
+
+function getInitialDark(): boolean {
+	try {
+		const stored = localStorage.getItem(STORAGE_KEY);
+		if (stored !== null) return stored === "true";
+		return window.matchMedia("(prefers-color-scheme: dark)").matches;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Manages dark mode by toggling the `dark` class on <html> and persisting
+ * the preference to localStorage.
+ */
+export function useDarkMode() {
+	const [isDark, setIsDark] = useState(false);
+
+	// Read stored/OS preference after mount (avoids SSR mismatch)
+	useEffect(() => {
+		const initial = getInitialDark();
+		setIsDark(initial);
+		document.documentElement.classList.toggle("dark", initial);
+	}, []);
+
+	function toggle() {
+		setIsDark((prev) => {
+			const next = !prev;
+			document.documentElement.classList.toggle("dark", next);
+			try {
+				localStorage.setItem(STORAGE_KEY, String(next));
+			} catch {}
+			return next;
+		});
+	}
+
+	return { isDark, toggle };
+}

--- a/src/test/topnav-switcher.test.tsx
+++ b/src/test/topnav-switcher.test.tsx
@@ -1,0 +1,152 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TopNav } from "@/components/layouts/TopNav";
+import { NetworkProvider } from "@/context/NetworkContext";
+
+vi.mock("next/navigation", () => ({
+	usePathname: () => "/dashboard/wallets",
+}));
+
+// TopNav calls useAuth — provide a minimal stub so the component renders
+vi.mock("@/context/AuthContext", () => ({
+	useAuth: () => ({ user: null, isLoading: false }),
+}));
+
+function renderTopNav(onMenuClick = vi.fn()) {
+	return render(
+		<NetworkProvider>
+			<TopNav onMenuClick={onMenuClick} />
+		</NetworkProvider>,
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Network switcher
+// ---------------------------------------------------------------------------
+
+describe("TopNav — network switcher", () => {
+	beforeEach(() => {
+		document.title = "";
+		// Ensure we start in a clean network state each test
+		localStorage.removeItem("mux_network");
+	});
+
+	it("renders Testnet and Mainnet switch buttons", () => {
+		renderTopNav();
+		expect(screen.getByRole("button", { name: "Testnet" })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Mainnet" })).toBeInTheDocument();
+	});
+
+	it("defaults to Mainnet active state", () => {
+		renderTopNav();
+		const mainnetBtn = screen.getByRole("button", { name: "Mainnet" });
+		// Active button has amber/blue highlight class
+		expect(mainnetBtn).toHaveClass("bg-blue-100");
+	});
+
+	it("switches to testnet when Testnet button is clicked", () => {
+		renderTopNav();
+		fireEvent.click(screen.getByRole("button", { name: "Testnet" }));
+		const testnetBtn = screen.getByRole("button", { name: "Testnet" });
+		expect(testnetBtn).toHaveClass("bg-amber-100");
+	});
+
+	it("switches back to mainnet when Mainnet button is clicked", () => {
+		renderTopNav();
+		fireEvent.click(screen.getByRole("button", { name: "Testnet" }));
+		fireEvent.click(screen.getByRole("button", { name: "Mainnet" }));
+		const mainnetBtn = screen.getByRole("button", { name: "Mainnet" });
+		expect(mainnetBtn).toHaveClass("bg-blue-100");
+	});
+
+	it("updates the network badge in the page title on network switch", () => {
+		renderTopNav();
+		// Mainnet badge shown by default
+		const badges = screen.getAllByText("Mainnet");
+		expect(badges.length).toBeGreaterThanOrEqual(1);
+
+		fireEvent.click(screen.getByRole("button", { name: "Testnet" }));
+		const testnetBadges = screen.getAllByText("Testnet");
+		expect(testnetBadges.length).toBeGreaterThanOrEqual(2); // switcher + h1 badge
+	});
+
+	it("updates document.title to reflect active network", () => {
+		document.title = "";
+		renderTopNav();
+		expect(document.title).toBe("Wallets · Mainnet — Mux");
+
+		fireEvent.click(screen.getByRole("button", { name: "Testnet" }));
+		expect(document.title).toBe("Wallets · Testnet — Mux");
+
+		fireEvent.click(screen.getByRole("button", { name: "Mainnet" }));
+		expect(document.title).toBe("Wallets · Mainnet — Mux");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Dark mode toggle
+// ---------------------------------------------------------------------------
+
+describe("TopNav — dark mode toggle", () => {
+	beforeEach(() => {
+		// Start each test in light mode
+		document.documentElement.classList.remove("dark");
+		localStorage.removeItem("mux_dark_mode");
+	});
+
+	it("renders the dark mode toggle button", () => {
+		renderTopNav();
+		expect(
+			screen.getByRole("button", { name: /switch to dark mode/i }),
+		).toBeInTheDocument();
+	});
+
+	it("toggles to dark mode on click", () => {
+		renderTopNav();
+		const toggle = screen.getByRole("button", { name: /switch to dark mode/i });
+		fireEvent.click(toggle);
+		expect(document.documentElement.classList.contains("dark")).toBe(true);
+	});
+
+	it("shows 'switch to light mode' label after enabling dark mode", () => {
+		renderTopNav();
+		fireEvent.click(screen.getByRole("button", { name: /switch to dark mode/i }));
+		expect(
+			screen.getByRole("button", { name: /switch to light mode/i }),
+		).toBeInTheDocument();
+	});
+
+	it("toggles back to light mode on second click", () => {
+		renderTopNav();
+		const toggle = screen.getByRole("button", { name: /switch to dark mode/i });
+		fireEvent.click(toggle); // → dark
+		fireEvent.click(screen.getByRole("button", { name: /switch to light mode/i })); // → light
+		expect(document.documentElement.classList.contains("dark")).toBe(false);
+	});
+
+	it("persists dark mode preference to localStorage", () => {
+		renderTopNav();
+		fireEvent.click(screen.getByRole("button", { name: /switch to dark mode/i }));
+		expect(localStorage.getItem("mux_dark_mode")).toBe("true");
+	});
+
+	it("persists light mode preference to localStorage", () => {
+		renderTopNav();
+		fireEvent.click(screen.getByRole("button", { name: /switch to dark mode/i }));
+		fireEvent.click(screen.getByRole("button", { name: /switch to light mode/i }));
+		expect(localStorage.getItem("mux_dark_mode")).toBe("false");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Menu button
+// ---------------------------------------------------------------------------
+
+describe("TopNav — menu button", () => {
+	it("calls onMenuClick when the mobile menu button is clicked", () => {
+		const onMenuClick = vi.fn();
+		renderTopNav(onMenuClick);
+		fireEvent.click(screen.getByRole("button", { name: /open sidebar/i }));
+		expect(onMenuClick).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary

Implements issues #291, #292, #293, and #294.

---

### #291 Analytics: Add dark mode styles
- New `useDarkMode` hook — reads OS preference, persists to `localStorage`, toggles `html.dark` class
- Moon/Sun icon toggle button added to TopNav
- `TransactionVolumeChart`: replaced hardcoded SVG colors (`#e4e4e7`, `#71717a`) with JS-computed values that respect the dark class
- `DashboardLayout` outer wrapper: added `dark:bg-zinc-950`
- `TopNav` header: added `dark:border-zinc-800 dark:bg-zinc-900/95` variants

### #292 Analytics: Add mobile layout polish
- `TopAssetsTable`: Change column hidden below `sm`, TVL/Transactions hidden below `md`
- Added `min-w-[480px]` on the table so `overflow-x-auto` scrolls correctly on narrow screens
- Responsive `px-4 sm:px-6` padding throughout; `truncate` on asset names
- `TopAssetsTableSkeleton` skeleton rows updated to mirror the same responsive visibility

### #293 Analytics: Add analytics tracking stub
- New `useAnalyticsTracking(pageName)` hook — fires `page_view` on mount; exports `track(event, props)`
- Dispatches `console.debug` outside production; swap the TODO line for any real SDK (Segment, PostHog, etc.)
- Wired to the analytics page: `handleRangeChange` calls `track('date_range_changed', { from, to })`

### #294 Network & Stellar UX: Add component tests
- `topnav-switcher.test.tsx` — TopNav network switcher (Testnet ↔ Mainnet, document.title updates) and dark mode toggle (on/off, localStorage persistence)
- `NetworkBadge.test.tsx` — invalid/unknown network value fallback tests
- `StatusIndicator.test.tsx` — invalid/unknown status value fallback tests  
- `useDarkMode.test.ts` — toggle, localStorage persistence, `html.dark` class mutation

## Testing
All new/modified tests pass. Pre-existing failures in `addressFormatter`, `recoveryApi`, `useRecoveryStatus`, etc. are unrelated to this PR and existed before these changes.

closes #291 
closes #292 
closes #293 
closes #294 