### PR TITLE
feat: Network & Stellar UX improvements (#304-#307)

### DIFF
--- a/src/app/wallet/page.tsx
+++ b/src/app/wallet/page.tsx
@@ -44,7 +44,7 @@ function WalletPageContent() {
 	return (
 		<div className="min-h-screen bg-neutral-50 text-neutral-900 font-sans p-6 md:p-12">
 			<div className="max-w-4xl mx-auto space-y-8">
-				<header className="flex items-center justify-between mb-8">
+				<header className="flex flex-col gap-4 mb-8 sm:flex-row sm:items-center sm:justify-between">
 					<div>
 						<h1 className="text-3xl font-bold tracking-tight text-neutral-900">
 							Wallet Details

--- a/src/components/wallet/NetworkBadge.stories.tsx
+++ b/src/components/wallet/NetworkBadge.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { NetworkBadge } from "./NetworkBadge";
+
+const meta: Meta<typeof NetworkBadge> = {
+	title: "Wallet/NetworkBadge",
+	component: NetworkBadge,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "centered",
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof NetworkBadge>;
+
+export const Mainnet: Story = {
+	args: { network: "mainnet" },
+};
+
+export const Testnet: Story = {
+	args: { network: "testnet" },
+};
+
+/** Falls back to mainnet when an invalid network value is provided. */
+export const InvalidFallback: Story = {
+	args: { network: "unknown" as never },
+};
+
+export const WithCustomClass: Story = {
+	args: { network: "testnet", className: "text-base px-4 py-1" },
+};
+
+/** Both badges side-by-side for comparison. */
+export const AllVariants: Story = {
+	render: () => (
+		<div className="flex gap-3">
+			<NetworkBadge network="mainnet" />
+			<NetworkBadge network="testnet" />
+		</div>
+	),
+};

--- a/src/components/wallet/NetworkFilter.stories.tsx
+++ b/src/components/wallet/NetworkFilter.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import type { WalletNetwork } from "@/types/wallet";
+import { NetworkFilter } from "./NetworkFilter";
+
+const meta: Meta<typeof NetworkFilter> = {
+	title: "Wallet/NetworkFilter",
+	component: NetworkFilter,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "centered",
+	},
+	argTypes: {
+		onNetworkChange: { action: "network changed" },
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof NetworkFilter>;
+
+export const AllSelected: Story = {
+	args: {
+		selectedNetwork: "all",
+	},
+};
+
+export const MainnetSelected: Story = {
+	args: {
+		selectedNetwork: "mainnet",
+	},
+};
+
+export const TestnetSelected: Story = {
+	args: {
+		selectedNetwork: "testnet",
+	},
+};
+
+export const Disabled: Story = {
+	args: {
+		selectedNetwork: "all",
+		disabled: true,
+	},
+};
+
+/** Interactive story — click buttons to switch the selected network. */
+export const Interactive: Story = {
+	render: () => {
+		const [network, setNetwork] = useState<WalletNetwork | "all">("all");
+		return (
+			<div className="space-y-3">
+				<NetworkFilter
+					selectedNetwork={network}
+					onNetworkChange={setNetwork}
+				/>
+				<p className="text-sm text-zinc-500">
+					Selected: <strong>{network}</strong>
+				</p>
+			</div>
+		);
+	},
+};
+
+/** Simulates a narrow mobile viewport. */
+export const MobileLayout: Story = {
+	parameters: {
+		viewport: { defaultViewport: "mobile1" },
+	},
+	render: () => {
+		const [network, setNetwork] = useState<WalletNetwork | "all">("all");
+		return (
+			<NetworkFilter
+				selectedNetwork={network}
+				onNetworkChange={setNetwork}
+				className="w-full"
+			/>
+		);
+	},
+};

--- a/src/components/wallet/NetworkFilter.tsx
+++ b/src/components/wallet/NetworkFilter.tsx
@@ -83,8 +83,9 @@ export function NetworkFilter({
 					aria-pressed={selectedNetwork === option.value}
 					aria-label={`Filter by ${option.label}`}
 					className={cn(
-						"transition-all",
-						selectedNetwork === option.value && "ring-2 ring-offset-2",
+						"flex-1 sm:flex-none transition-all",
+						selectedNetwork === option.value &&
+							"ring-2 ring-offset-2 dark:ring-offset-background",
 					)}
 				>
 					{option.label}

--- a/src/components/wallet/__tests__/NetworkFilter.darkmode-mobile.test.tsx
+++ b/src/components/wallet/__tests__/NetworkFilter.darkmode-mobile.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * Tests covering changes from #304-307:
+ *  - #306: dark mode ring-offset on active NetworkFilter button
+ *  - #307: mobile flex-1 class on NetworkFilter buttons
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { NetworkFilter } from "@/components/wallet/NetworkFilter";
+
+const noop = () => {};
+
+describe("NetworkFilter – #306 dark mode ring-offset", () => {
+	it("applies dark:ring-offset-background to the active button", () => {
+		render(<NetworkFilter selectedNetwork="testnet" onNetworkChange={noop} />);
+		const btn = screen.getByLabelText("Filter by Testnet");
+		expect(btn).toHaveClass("dark:ring-offset-background");
+	});
+
+	it("does NOT apply ring-2 to inactive buttons", () => {
+		render(<NetworkFilter selectedNetwork="testnet" onNetworkChange={noop} />);
+		const mainnetBtn = screen.getByLabelText("Filter by Mainnet");
+		expect(mainnetBtn).not.toHaveClass("ring-2");
+	});
+
+	it("moves ring to newly active button on selection change", () => {
+		const { rerender } = render(
+			<NetworkFilter selectedNetwork="testnet" onNetworkChange={noop} />,
+		);
+		rerender(<NetworkFilter selectedNetwork="mainnet" onNetworkChange={noop} />);
+		const mainnetBtn = screen.getByLabelText("Filter by Mainnet");
+		const testnetBtn = screen.getByLabelText("Filter by Testnet");
+		expect(mainnetBtn).toHaveClass("ring-2");
+		expect(testnetBtn).not.toHaveClass("ring-2");
+	});
+});
+
+describe("NetworkFilter – #307 mobile layout (flex-1 sm:flex-none)", () => {
+	it("applies flex-1 to all buttons for mobile stretch", () => {
+		render(<NetworkFilter selectedNetwork="all" onNetworkChange={noop} />);
+		const buttons = screen.getAllByRole("button");
+		for (const btn of buttons) {
+			expect(btn).toHaveClass("flex-1");
+		}
+	});
+
+	it("applies sm:flex-none to all buttons to revert on larger screens", () => {
+		render(<NetworkFilter selectedNetwork="all" onNetworkChange={noop} />);
+		const buttons = screen.getAllByRole("button");
+		for (const btn of buttons) {
+			expect(btn).toHaveClass("sm:flex-none");
+		}
+	});
+});

--- a/src/context/NetworkContext.tsx
+++ b/src/context/NetworkContext.tsx
@@ -15,13 +15,37 @@ function readStored(): WalletNetwork {
 	return DEFAULT;
 }
 
+/** Shape of the value provided by {@link NetworkContext}. */
 interface NetworkContextValue {
+	/** The currently active Stellar network. */
 	network: WalletNetwork;
+	/**
+	 * Update the active network. The new value is persisted to `localStorage`
+	 * so it survives page refreshes.
+	 *
+	 * @param n - The network to activate (`"mainnet"` or `"testnet"`).
+	 */
 	setNetwork: (n: WalletNetwork) => void;
 }
 
 const NetworkContext = createContext<NetworkContextValue | null>(null);
 
+/**
+ * NetworkProvider wraps the application (or a subtree) and makes the active
+ * Stellar network available to all descendants via {@link useNetwork}.
+ *
+ * - Reads the persisted network from `localStorage` on first mount.
+ * - Falls back to `"mainnet"` when no valid value is stored or when
+ *   `localStorage` is unavailable (e.g. SSR or private browsing).
+ * - Persists every network change back to `localStorage`.
+ *
+ * @example
+ * ```tsx
+ * <NetworkProvider>
+ *   <App />
+ * </NetworkProvider>
+ * ```
+ */
 export function NetworkProvider({ children }: { children: React.ReactNode }) {
 	const [network, setNetworkState] = useState<WalletNetwork>(DEFAULT);
 
@@ -43,6 +67,21 @@ export function NetworkProvider({ children }: { children: React.ReactNode }) {
 	);
 }
 
+/**
+ * Hook to access the active Stellar network and the function to change it.
+ *
+ * Must be called inside a {@link NetworkProvider}; throws otherwise.
+ *
+ * @returns `{ network, setNetwork }` — the current network and an updater.
+ *
+ * @example
+ * ```tsx
+ * const { network, setNetwork } = useNetwork();
+ * // network === "mainnet" | "testnet"
+ * ```
+ *
+ * @throws {Error} When called outside of `NetworkProvider`.
+ */
 export function useNetwork(): NetworkContextValue {
 	const ctx = useContext(NetworkContext);
 	if (!ctx) throw new Error("useNetwork must be used within NetworkProvider");


### PR DESCRIPTION
#304: Add Storybook stories for NetworkBadge and NetworkFilter
- CSF3 format stories with autodocs, all variants, interactive demo, mobile viewport story

#305: Document props usage with JSDoc
- Full JSDoc on NetworkProvider and useNetwork (NetworkContext.tsx)
- NetworkBadge and NetworkFilter already had JSDoc; NetworkContext lacked it

#306: Add dark mode styles
- NetworkFilter active button: add dark:ring-offset-background so the ring renders correctly against dark backgrounds

#307: Mobile layout polish
- NetworkFilter buttons: flex-1 on mobile, sm:flex-none on sm+ screens so buttons stretch full-width on small viewports
- wallet/page.tsx header: flex-col gap-4 on mobile, sm:flex-row on sm+

Tests: 5 new passing tests in NetworkFilter.darkmode-mobile.test.tsx

closes #304 
closes #305 
closes #306 
closes #307 