### PR TITLE
feat(#273): add toast feedback to SpendingLimitsCard

### DIFF
--- a/src/components/dashboard/SpendingLimitsCard.test.tsx
+++ b/src/components/dashboard/SpendingLimitsCard.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SpendingLimitsCard } from "./SpendingLimitsCard";
 
 describe("SpendingLimitsCard", () => {
@@ -208,5 +209,49 @@ describe("SpendingLimitsCard loading state", () => {
 		expect(
 			screen.getByRole("heading", { name: /spending limits/i }),
 		).toBeInTheDocument();
+	});
+});
+
+describe("SpendingLimitsCard toast feedback", () => {
+	beforeEach(() => {
+		vi.stubGlobal("localStorage", {
+			getItem: vi.fn().mockReturnValue(null),
+			setItem: vi.fn(),
+		});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("shows success toast after saving valid settings", async () => {
+		const user = userEvent.setup();
+		render(<SpendingLimitsCard />);
+
+		await user.click(screen.getByRole("button", { name: /save settings/i }));
+
+		expect(screen.getByRole("status")).toBeInTheDocument();
+		expect(screen.getByText("Success")).toBeInTheDocument();
+		expect(screen.getByText(/spending limits saved/i)).toBeInTheDocument();
+	});
+
+	it("shows error toast when localStorage throws", async () => {
+		vi.mocked(localStorage.setItem).mockImplementation(() => {
+			throw new Error("QuotaExceededError");
+		});
+
+		const user = userEvent.setup();
+		render(<SpendingLimitsCard />);
+
+		await user.click(screen.getByRole("button", { name: /save settings/i }));
+
+		expect(screen.getByRole("status")).toBeInTheDocument();
+		expect(screen.getByText("Error")).toBeInTheDocument();
+		expect(screen.getByText(/failed to save/i)).toBeInTheDocument();
+	});
+
+	it("toast is not visible before saving", () => {
+		render(<SpendingLimitsCard />);
+		expect(screen.queryByRole("status")).not.toBeInTheDocument();
 	});
 });

--- a/src/components/dashboard/SpendingLimitsCard.tsx
+++ b/src/components/dashboard/SpendingLimitsCard.tsx
@@ -31,6 +31,8 @@ export function SpendingLimitsCard({
 	const [dailyLimit, setDailyLimit] = useState("5000");
 	const [transactionLimit, setTransactionLimit] = useState("1000");
 	const [toastOpen, setToastOpen] = useState(false);
+	const [toastVariant, setToastVariant] = useState<"success" | "error">("success");
+	const [toastMessage, setToastMessage] = useState("Spending limits saved.");
 
 	const toastTimeoutRef = useRef<number | null>(null);
 
@@ -74,23 +76,27 @@ export function SpendingLimitsCard({
 		return <SpendingLimitsCardSkeleton />;
 	}
 
-	const handleSave = () => {
-		window.localStorage.setItem(
-			STORAGE_KEY,
-			JSON.stringify({
-				dailyLimit: safeSaveValue(dailyLimit),
-				transactionLimit: safeSaveValue(transactionLimit),
-			}),
-		);
-
+	const showToast = (variant: "success" | "error", message: string) => {
+		setToastVariant(variant);
+		setToastMessage(message);
 		setToastOpen(true);
-		if (toastTimeoutRef.current) {
-			window.clearTimeout(toastTimeoutRef.current);
-		}
+		if (toastTimeoutRef.current) window.clearTimeout(toastTimeoutRef.current);
+		toastTimeoutRef.current = window.setTimeout(() => setToastOpen(false), 3000);
+	};
 
-		toastTimeoutRef.current = window.setTimeout(() => {
-			setToastOpen(false);
-		}, 3000);
+	const handleSave = () => {
+		try {
+			window.localStorage.setItem(
+				STORAGE_KEY,
+				JSON.stringify({
+					dailyLimit: safeSaveValue(dailyLimit),
+					transactionLimit: safeSaveValue(transactionLimit),
+				}),
+			);
+			showToast("success", "Spending limits saved.");
+		} catch {
+			showToast("error", "Failed to save. Please try again.");
+		}
 	};
 
 	return (
@@ -221,7 +227,7 @@ export function SpendingLimitsCard({
 					</Button>
 				</div>
 			</div>
-			<Toast open={toastOpen} message="Spending limits saved." />
+			<Toast open={toastOpen} message={toastMessage} variant={toastVariant} />
 		</>
 	);
 }

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,17 +1,33 @@
+type ToastVariant = "success" | "error";
+
 interface ToastProps {
 	open: boolean;
 	message: string;
+	variant?: ToastVariant;
 }
 
-export function Toast({ open, message }: ToastProps) {
-	if (!open) {
-		return null;
-	}
+const variantStyles: Record<ToastVariant, { label: string; classes: string }> = {
+	success: {
+		label: "Success",
+		classes: "bg-zinc-950/95 text-white ring-white/10",
+	},
+	error: {
+		label: "Error",
+		classes: "bg-red-950/95 text-white ring-red-500/20",
+	},
+};
+
+export function Toast({ open, message, variant = "success" }: ToastProps) {
+	if (!open) return null;
+
+	const { label, classes } = variantStyles[variant];
 
 	return (
-		<div className="fixed right-4 bottom-4 z-50 max-w-xs rounded-2xl bg-zinc-950/95 p-4 text-white shadow-2xl ring-1 ring-white/10 backdrop-blur-md">
+		<div
+			className={`fixed right-4 bottom-4 z-50 max-w-xs rounded-2xl p-4 shadow-2xl ring-1 backdrop-blur-md ${classes}`}
+		>
 			<div role="status" aria-live="polite" className="space-y-1">
-				<p className="text-sm font-semibold">Success</p>
+				<p className="text-sm font-semibold">{label}</p>
 				<p className="text-sm text-zinc-200">{message}</p>
 			</div>
 		</div>


### PR DESCRIPTION
- Toast gains variant prop: 'success' (default) and 'error'
- Success toast shown on save; error toast on localStorage failure
- Dynamic message and variant driven by state
- Tests: 3 new toast feedback test cases
closes #270