### PR TITLE
feat(transactions): add skeleton, responsive layout, keyboard nav, co…

### DIFF
--- a/src/components/TransactionsTable/TransactionsTable.test.tsx
+++ b/src/components/TransactionsTable/TransactionsTable.test.tsx
@@ -1,39 +1,209 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import TransactionsTable from "./TransactionsTable";
-import { mockTransactions } from "@/mock-data/transactions";
 
 describe("TransactionsTable", () => {
+	// ─── Existing functionality ───────────────────────────────────────────────
+
 	it("renders transactions correctly", () => {
 		render(<TransactionsTable />);
-		// Check that the header is rendered
 		expect(screen.getByText("Transactions")).toBeInTheDocument();
-		// Check that at least one mock transaction is rendered
-		// e.g. amount 250.00
 		expect(screen.getByText("250.00")).toBeInTheDocument();
 	});
 
 	it("filters transactions by address prop", () => {
-		const targetAddress = "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI";
+		const targetAddress =
+			"GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI";
 		render(<TransactionsTable address={targetAddress} />);
-		
-		// The transaction from/to targetAddress should be present
 		expect(screen.getByText("250.00")).toBeInTheDocument();
-		
-		// Transaction not involving targetAddress should NOT be present (e.g. 50.50 amount)
+		// Transaction not involving targetAddress should NOT be present
 		expect(screen.queryByText("50.50")).not.toBeInTheDocument();
 	});
 
 	it("filters by search query", async () => {
 		const user = userEvent.setup();
 		render(<TransactionsTable />);
-		
 		const searchInput = screen.getByPlaceholderText("Hash, address, memo…");
 		await user.type(searchInput, "payment-ref");
-		
 		expect(screen.getByText("250.00")).toBeInTheDocument();
-		// The 1000.00 tx doesn't have this memo
 		expect(screen.queryByText("1,000.00")).not.toBeInTheDocument();
+	});
+
+	// ─── #253 Loading skeleton ────────────────────────────────────────────────
+
+	describe("loading skeleton (#253)", () => {
+		it("renders skeleton when isLoading=true", () => {
+			render(<TransactionsTable isLoading />);
+			const status = screen.getByRole("status");
+			expect(status).toHaveAttribute("aria-label", "Loading transactions");
+			expect(status).toHaveAttribute("aria-busy", "true");
+		});
+
+		it("does not render any transaction rows while loading", () => {
+			render(<TransactionsTable isLoading />);
+			expect(screen.queryAllByTestId("tx-row")).toHaveLength(0);
+		});
+
+		it("renders skeleton bones (animate-pulse elements)", () => {
+			render(<TransactionsTable isLoading />);
+			const bones = document.querySelectorAll(".animate-pulse");
+			expect(bones.length).toBeGreaterThan(0);
+		});
+
+		it("renders transaction rows when isLoading=false (default)", () => {
+			render(<TransactionsTable />);
+			expect(screen.getAllByTestId("tx-row").length).toBeGreaterThan(0);
+		});
+
+		it("transitions from loading to loaded when prop changes", () => {
+			const { rerender } = render(<TransactionsTable isLoading />);
+			expect(screen.getByRole("status")).toBeInTheDocument();
+			rerender(<TransactionsTable isLoading={false} />);
+			expect(screen.queryByRole("status")).not.toBeInTheDocument();
+			expect(screen.getAllByTestId("tx-row").length).toBeGreaterThan(0);
+		});
+	});
+
+	// ─── #254 Responsive layout ───────────────────────────────────────────────
+
+	describe("responsive layout (#254)", () => {
+		it("renders the search input", () => {
+			render(<TransactionsTable />);
+			expect(
+				screen.getByPlaceholderText("Hash, address, memo…"),
+			).toBeInTheDocument();
+		});
+
+		it("renders status and network filter selects", () => {
+			render(<TransactionsTable />);
+			expect(screen.getByLabelText("Filter by status")).toBeInTheDocument();
+			expect(screen.getByLabelText("Filter by network")).toBeInTheDocument();
+		});
+
+		it("renders mobile card layout elements alongside desktop ones", () => {
+			render(<TransactionsTable />);
+			// Both desktop and mobile rows are in DOM; CSS hides them via lg:hidden / hidden lg:grid
+			const rows = screen.getAllByTestId("tx-row");
+			expect(rows.length).toBeGreaterThan(0);
+		});
+
+		it("shows 'Reset' button only when filters are active", async () => {
+			const user = userEvent.setup();
+			render(<TransactionsTable />);
+			// Reset button not rendered before any filter is applied
+			expect(screen.queryByRole("button", { name: "Reset" })).not.toBeInTheDocument();
+			await user.selectOptions(screen.getByLabelText("Filter by status"), "completed");
+			// Reset button appears after a filter is applied
+			expect(
+				screen.getByRole("button", { name: "Reset" }),
+			).toBeInTheDocument();
+		});
+
+		it("pagination displays within a sm:flex-row container", () => {
+			render(<TransactionsTable />);
+			// Pagination controls rendered
+			expect(screen.getByLabelText("Previous page")).toBeInTheDocument();
+			expect(screen.getByLabelText("Next page")).toBeInTheDocument();
+		});
+	});
+
+	// ─── #255 Keyboard navigation ─────────────────────────────────────────────
+
+	describe("keyboard navigation (#255)", () => {
+		it("sortable column headers have tabIndex=0", () => {
+			render(<TransactionsTable />);
+			const sortableHeaders = screen.getAllByRole("columnheader", {
+				name: /Tx Hash|Amount|Date/i,
+			});
+			for (const header of sortableHeaders) {
+				expect(header).toHaveAttribute("tabindex", "0");
+			}
+		});
+
+		it("activates sort on Enter key", async () => {
+			const user = userEvent.setup();
+			render(<TransactionsTable />);
+			const hashHeader = screen.getByRole("columnheader", { name: /Tx Hash/i });
+			hashHeader.focus();
+			await user.keyboard("{Enter}");
+			expect(hashHeader).toHaveAttribute("aria-sort", "ascending");
+		});
+
+		it("activates sort on Space key", async () => {
+			const user = userEvent.setup();
+			render(<TransactionsTable />);
+			const amountHeader = screen.getByRole("columnheader", {
+				name: /Amount/i,
+			});
+			amountHeader.focus();
+			await user.keyboard(" ");
+			expect(amountHeader).toHaveAttribute("aria-sort");
+		});
+
+		it("toggles sort direction on repeated Enter", async () => {
+			const user = userEvent.setup();
+			render(<TransactionsTable />);
+			const dateHeader = screen.getByRole("columnheader", { name: /Date/i });
+			dateHeader.focus();
+			// Default sort is already 'desc' for createdAt; pressing Enter → asc
+			await user.keyboard("{Enter}");
+			expect(dateHeader).toHaveAttribute("aria-sort", "ascending");
+			await user.keyboard("{Enter}");
+			expect(dateHeader).toHaveAttribute("aria-sort", "descending");
+		});
+
+		it("non-sortable columns do not have tabIndex", () => {
+			render(<TransactionsTable />);
+			const fromHeader = screen.getByRole("columnheader", { name: /^From$/i });
+			expect(fromHeader).not.toHaveAttribute("tabindex");
+		});
+	});
+
+	describe("copy-to-clipboard (#256)", () => {
+		it("renders copy buttons for tx hash, from, and to on each row", () => {
+			render(<TransactionsTable />);
+			// Each visible row has 3 copy buttons (hash, from, to)
+			const copyButtons = screen
+				.getAllByRole("button")
+				.filter((b) => b.getAttribute("aria-label")?.includes("Copy"));
+			// At least one full set of 3 per rendered row (rows × 3 per layout × 2 layouts)
+			expect(copyButtons.length).toBeGreaterThanOrEqual(3);
+		});
+
+		it("calls clipboard.writeText when a copy button is clicked", async () => {
+			const writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue();
+			const user = userEvent.setup();
+			render(<TransactionsTable />);
+			const [firstCopyBtn] = screen
+				.getAllByRole("button")
+				.filter((b) => b.getAttribute("aria-label")?.includes("Copy"));
+			await user.click(firstCopyBtn);
+			expect(writeText).toHaveBeenCalledTimes(1);
+			writeText.mockRestore();
+		});
+
+		it("copy button aria-label includes 'Copied!' after click", async () => {
+			const user = userEvent.setup();
+			render(<TransactionsTable />);
+			const hashCopyBtn = screen.getAllByRole("button", {
+				name: /Copy transaction hash/i,
+			})[0];
+			await user.click(hashCopyBtn);
+			// After copy, label changes to "Copied!"
+			expect(
+				screen.getAllByRole("button", { name: "Copied!" })[0],
+			).toBeInTheDocument();
+		});
+
+		it("copy buttons are keyboard-accessible (have no tabIndex exclusion)", () => {
+			render(<TransactionsTable />);
+			const copyButtons = screen
+				.getAllByRole("button")
+				.filter((b) => b.getAttribute("aria-label")?.includes("Copy"));
+			for (const btn of copyButtons) {
+				expect(btn).not.toHaveAttribute("tabindex", "-1");
+			}
+		});
 	});
 });

--- a/src/components/TransactionsTable/TransactionsTable.tsx
+++ b/src/components/TransactionsTable/TransactionsTable.tsx
@@ -2,13 +2,17 @@
 
 import {
 	ArrowUpDown,
+	Check,
 	ChevronLeft,
 	ChevronRight,
+	Copy,
 	Filter,
 	Search,
 	X,
 } from "lucide-react";
 import React, { useMemo, useState } from "react";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { mockTransactions } from "@/mock-data/transactions";
 import type {
 	Transaction,
@@ -36,7 +40,6 @@ function formatDate(iso: string): string {
 
 // --- Sub-components ---
 
-/** Default sort: newest transactions first. */
 type SortConfig = {
 	key: keyof Transaction;
 	direction: "asc" | "desc";
@@ -79,9 +82,112 @@ const NetworkBadge = ({ network }: { network: TransactionNetwork }) => {
 	);
 };
 
+/** Inline copy button that shows a check on success */
+function CopyButton({ text, label }: { text: string; label: string }) {
+	const { copy, copied } = useCopyToClipboard();
+	return (
+		<button
+			type="button"
+			onClick={(e) => {
+				e.stopPropagation();
+				copy(text, text);
+			}}
+			aria-label={copied ? "Copied!" : label}
+			title={copied ? "Copied!" : label}
+			className="ml-1 inline-flex shrink-0 items-center justify-center rounded p-0.5 text-slate-400 opacity-0 transition-opacity hover:text-slate-600 group-hover:opacity-100 focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+		>
+			{copied ? <Check size={12} aria-hidden /> : <Copy size={12} aria-hidden />}
+		</button>
+	);
+}
+
+/** Skeleton for the transactions table while loading */
+function TransactionsTableSkeleton({ rows = 5 }: { rows?: number }) {
+	return (
+		<div
+			className="bg-white border border-slate-200 rounded-xl shadow-sm overflow-hidden"
+			role="status"
+			aria-label="Loading transactions"
+			aria-busy="true"
+			aria-live="polite"
+		>
+			{/* Desktop header skeleton */}
+			<div className="hidden lg:grid grid-cols-12 gap-2 p-4 border-b border-slate-100 bg-slate-50/50">
+				{[3, 2, 2, 2, 1, 1, 1].map((span, i) => (
+					// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton
+					<div key={i} className={`col-span-${span}`}>
+						<Skeleton className="h-3 w-16" />
+					</div>
+				))}
+			</div>
+
+			{/* Skeleton rows */}
+			<div className="divide-y divide-slate-100">
+				{Array.from({ length: rows }).map((_, i) => (
+					// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton
+					<div key={i} className="p-4">
+						{/* Desktop row */}
+						<div className="hidden lg:grid grid-cols-12 gap-2 items-center">
+							<div className="col-span-3 space-y-1">
+								<Skeleton className="h-4 w-32" />
+								<Skeleton className="h-3 w-20" />
+							</div>
+							<div className="col-span-2">
+								<Skeleton className="h-4 w-24" />
+							</div>
+							<div className="col-span-2">
+								<Skeleton className="h-4 w-24" />
+							</div>
+							<div className="col-span-2">
+								<Skeleton className="h-4 w-16" />
+							</div>
+							<div className="col-span-1">
+								<Skeleton className="h-5 w-16 rounded-full" />
+							</div>
+							<div className="col-span-1">
+								<Skeleton className="h-5 w-16 rounded" />
+							</div>
+							<div className="col-span-1">
+								<Skeleton className="h-4 w-20" />
+							</div>
+						</div>
+
+						{/* Mobile card */}
+						<div className="lg:hidden space-y-2">
+							<div className="flex items-center justify-between">
+								<Skeleton className="h-4 w-28" />
+								<div className="flex gap-2">
+									<Skeleton className="h-5 w-14 rounded" />
+									<Skeleton className="h-5 w-16 rounded-full" />
+								</div>
+							</div>
+							<div className="flex justify-between">
+								<Skeleton className="h-4 w-32" />
+								<Skeleton className="h-4 w-32" />
+							</div>
+							<div className="flex justify-between">
+								<Skeleton className="h-4 w-16" />
+								<Skeleton className="h-4 w-24" />
+							</div>
+						</div>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}
+
 // --- Main Component ---
 
-export default function TransactionsTable({ address }: { address?: string } = {}) {
+export interface TransactionsTableProps {
+	address?: string;
+	isLoading?: boolean;
+}
+
+export default function TransactionsTable({
+	address,
+	isLoading = false,
+}: TransactionsTableProps = {}) {
 	const [search, setSearch] = useState("");
 	const [statusFilter, setStatusFilter] = useState<"all" | TransactionStatus>(
 		"all",
@@ -95,9 +201,7 @@ export default function TransactionsTable({ address }: { address?: string } = {}
 
 	const filteredData = useMemo(() => {
 		return mockTransactions.filter((tx) => {
-			if (address && tx.from !== address && tx.to !== address) {
-				return false;
-			}
+			if (address && tx.from !== address && tx.to !== address) return false;
 			const q = search.toLowerCase();
 			const matchesSearch =
 				tx.hash.toLowerCase().includes(q) ||
@@ -110,7 +214,7 @@ export default function TransactionsTable({ address }: { address?: string } = {}
 				networkFilter === "all" || tx.network === networkFilter;
 			return matchesSearch && matchesStatus && matchesNetwork;
 		});
-	}, [search, statusFilter, networkFilter]);
+	}, [search, statusFilter, networkFilter, address]);
 
 	const sortedData = useMemo(() => {
 		return [...filteredData].sort((a, b) => {
@@ -136,14 +240,18 @@ export default function TransactionsTable({ address }: { address?: string } = {}
 		);
 	};
 
-	const handlePageChange = (page: number) => {
-		if (page >= 1 && page <= totalPages) setCurrentPage(page);
+	const handleSortKeyDown = (
+		e: React.KeyboardEvent,
+		key: keyof Transaction,
+	) => {
+		if (e.key === "Enter" || e.key === " ") {
+			e.preventDefault();
+			handleSort(key);
+		}
 	};
 
-	const handleItemsPerPageChange = (newSize: number) => {
-		setItemsPerPage(newSize);
-		// Reset to page 1 when changing page size
-		setCurrentPage(1);
+	const handlePageChange = (page: number) => {
+		if (page >= 1 && page <= totalPages) setCurrentPage(page);
 	};
 
 	const clearFilters = () => {
@@ -158,9 +266,9 @@ export default function TransactionsTable({ address }: { address?: string } = {}
 		search.length > 0 || statusFilter !== "all" || networkFilter !== "all";
 
 	return (
-		<div className="w-full max-w-6xl mx-auto p-4 md:p-8 space-y-6 font-sans">
+		<div className="w-full max-w-6xl mx-auto p-4 sm:p-6 md:p-8 space-y-6 font-sans">
 			{/* Header */}
-			<div className="flex flex-col md:flex-row md:items-end justify-between gap-4">
+			<div className="flex flex-col sm:flex-row sm:items-end justify-between gap-4">
 				<div>
 					<h2 className="text-2xl font-bold text-slate-900 tracking-tight">
 						Transactions
@@ -170,17 +278,18 @@ export default function TransactionsTable({ address }: { address?: string } = {}
 					</p>
 				</div>
 
-				<div className="flex flex-col sm:flex-row gap-3 w-full md:w-auto">
+				<div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
 					{/* Search */}
 					<div className="relative flex-grow sm:flex-grow-0 sm:w-64">
 						<Search
 							className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400"
 							size={16}
+							aria-hidden
 						/>
 						<input
 							type="text"
 							placeholder="Hash, address, memo…"
-						aria-label="Search transactions"
+							aria-label="Search transactions"
 							className="w-full pl-9 pr-8 py-2 bg-white border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500/20 focus:border-indigo-500 transition-all placeholder:text-slate-400"
 							value={search}
 							onChange={(e) => {
@@ -190,11 +299,12 @@ export default function TransactionsTable({ address }: { address?: string } = {}
 						/>
 						{search && (
 							<button
+								type="button"
 								onClick={() => setSearch("")}
 								className="absolute right-2 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
 								aria-label="Clear search"
 							>
-								<X size={14} />
+								<X size={14} aria-hidden />
 							</button>
 						)}
 					</div>
@@ -204,6 +314,7 @@ export default function TransactionsTable({ address }: { address?: string } = {}
 						<Filter
 							className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none"
 							size={16}
+							aria-hidden
 						/>
 						<select
 							className="w-full sm:w-36 pl-9 pr-4 py-2 bg-white border border-slate-200 text-slate-700 text-sm rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/20 focus:border-indigo-500 appearance-none cursor-pointer"
@@ -240,6 +351,7 @@ export default function TransactionsTable({ address }: { address?: string } = {}
 
 					{hasActiveFilters && (
 						<button
+							type="button"
 							onClick={clearFilters}
 							className="hidden sm:flex items-center justify-center px-3 text-xs font-medium text-rose-600 hover:text-rose-700 hover:bg-rose-50 rounded-lg transition-colors"
 						>
@@ -249,237 +361,275 @@ export default function TransactionsTable({ address }: { address?: string } = {}
 				</div>
 			</div>
 
-			{/* Table */}
-			<div className="bg-white border border-slate-200 rounded-xl shadow-sm overflow-hidden">
-				{/* Desktop header */}
-				<div className="hidden lg:grid grid-cols-12 gap-2 p-4 border-b border-slate-100 bg-slate-50/50 text-xs font-semibold text-slate-500 uppercase tracking-wider select-none">
+			{/* Loading skeleton */}
+			{isLoading ? (
+				<TransactionsTableSkeleton />
+			) : (
+				<div className="bg-white border border-slate-200 rounded-xl shadow-sm overflow-hidden">
+					{/* Desktop header */}
 					<div
-						className="col-span-3 flex items-center gap-1 cursor-pointer hover:text-indigo-600"
-						role="button"
-						aria-sort={
-							sortConfig.key === "hash"
-								? sortConfig.direction === "asc"
-									? "ascending"
-									: "descending"
-								: "none"
-						}
-						onClick={() => handleSort("hash")}
+						className="hidden lg:grid grid-cols-12 gap-2 p-4 border-b border-slate-100 bg-slate-50/50 text-xs font-semibold text-slate-500 uppercase tracking-wider select-none"
+						role="row"
 					>
-						Tx Hash
-						{sortConfig.key === "hash" && <ArrowUpDown size={12} />}
+						{(
+							[
+								{ key: "hash", label: "Tx Hash", span: 3, sortable: true },
+								{ key: "from", label: "From", span: 2, sortable: false },
+								{ key: "to", label: "To", span: 2, sortable: false },
+								{
+									key: "amountXlm",
+									label: "Amount (XLM)",
+									span: 2,
+									sortable: true,
+								},
+								{ key: "status", label: "Status", span: 1, sortable: false },
+								{ key: "network", label: "Network", span: 1, sortable: false },
+								{
+									key: "createdAt",
+									label: "Date",
+									span: 1,
+									sortable: true,
+								},
+							] as const
+						).map(({ key, label, span, sortable }) =>
+							sortable ? (
+								<div
+									key={key}
+									role="columnheader"
+									aria-sort={
+										sortConfig.key === key
+											? sortConfig.direction === "asc"
+												? "ascending"
+												: "descending"
+											: "none"
+									}
+									tabIndex={0}
+									className={`col-span-${span} flex items-center gap-1 cursor-pointer hover:text-indigo-600 focus:outline-none focus:text-indigo-600 focus:underline`}
+									onClick={() => handleSort(key as keyof Transaction)}
+									onKeyDown={(e) =>
+										handleSortKeyDown(e, key as keyof Transaction)
+									}
+								>
+									{label}
+									{sortConfig.key === key && (
+										<ArrowUpDown size={12} aria-hidden />
+									)}
+								</div>
+							) : (
+								<div
+									key={key}
+									role="columnheader"
+									className={`col-span-${span}`}
+								>
+									{label}
+								</div>
+							),
+						)}
 					</div>
-					<div className="col-span-2">From</div>
-					<div className="col-span-2">To</div>
-					<div
-						className="col-span-2 flex items-center gap-1 cursor-pointer hover:text-indigo-600"
-						role="button"
-						aria-sort={
-							sortConfig.key === "amountXlm"
-								? sortConfig.direction === "asc"
-									? "ascending"
-									: "descending"
-								: "none"
-						}
-						onClick={() => handleSort("amountXlm")}
-					>
-						Amount (XLM)
-						{sortConfig.key === "amountXlm" && <ArrowUpDown size={12} />}
-					</div>
-					<div className="col-span-1">Status</div>
-					<div className="col-span-1">Network</div>
-					<div
-						className="col-span-1 flex items-center gap-1 cursor-pointer hover:text-indigo-600"
-						role="button"
-						aria-sort={
-							sortConfig.key === "createdAt"
-								? sortConfig.direction === "asc"
-									? "ascending"
-									: "descending"
-								: "none"
-						}
-						onClick={() => handleSort("createdAt")}
-					>
-						Date
-						{sortConfig.key === "createdAt" && <ArrowUpDown size={12} />}
-					</div>
-				</div>
 
-				<div className="divide-y divide-slate-100">
-					{currentData.length > 0 ? (
-						currentData.map((tx) => (
+					<div className="divide-y divide-slate-100" role="rowgroup">
+						{currentData.length > 0 ? (
+							currentData.map((tx) => (
 								<div
 									key={tx.hash}
 									data-testid="tx-row"
+									role="row"
 									className="group p-4 hover:bg-slate-50 transition-colors"
-							>
-								{/* Desktop row */}
-								<div className="hidden lg:grid grid-cols-12 gap-2 items-center">
-									<div className="col-span-3">
-										<span
-											className="font-mono text-xs text-indigo-600 truncate block"
-											title={tx.hash}
-										>
-											{truncate(tx.hash, 8, 6)}
-										</span>
-										{tx.memo && (
-											<span className="text-xs text-slate-400 truncate block">
-												{tx.memo}
+								>
+									{/* Desktop row */}
+									<div className="hidden lg:grid grid-cols-12 gap-2 items-center">
+										<div className="col-span-3 flex items-center">
+											<span
+												className="font-mono text-xs text-indigo-600 truncate"
+												title={tx.hash}
+											>
+												{truncate(tx.hash, 8, 6)}
 											</span>
-										)}
-									</div>
-									<div
-										className="col-span-2 font-mono text-xs text-slate-600 truncate"
-										title={tx.from}
-									>
-										{truncate(tx.from)}
-									</div>
-									<div
-										className="col-span-2 font-mono text-xs text-slate-600 truncate"
-										title={tx.to}
-									>
-										{truncate(tx.to)}
-									</div>
-									<div className="col-span-2 font-semibold text-sm tabular-nums text-slate-900">
-										{Number(tx.amountXlm).toLocaleString(undefined, {
-											minimumFractionDigits: 2,
-											maximumFractionDigits: 7,
-										})}
-									</div>
-									<div className="col-span-1">
-										<StatusPill status={tx.status} />
-									</div>
-									<div className="col-span-1">
-										<NetworkBadge network={tx.network} />
-									</div>
-									<div className="col-span-1 text-xs text-slate-500">
-										{formatDate(tx.createdAt)}
-									</div>
-								</div>
-
-								{/* Mobile card */}
-								<div className="lg:hidden space-y-2">
-									<div className="flex items-center justify-between">
-										<span
-											className="font-mono text-xs text-indigo-600"
-											title={tx.hash}
-										>
-											{truncate(tx.hash, 8, 6)}
-										</span>
-										<div className="flex items-center gap-2">
-											<NetworkBadge network={tx.network} />
-											<StatusPill status={tx.status} />
+											<CopyButton
+												text={tx.hash}
+												label={`Copy transaction hash ${tx.hash}`}
+											/>
+											{tx.memo && (
+												<span className="text-xs text-slate-400 truncate block">
+													{tx.memo}
+												</span>
+											)}
 										</div>
-									</div>
-									<div className="flex justify-between text-xs text-slate-500">
-										<span>
-											<span className="font-medium text-slate-700">From: </span>
-											<span className="font-mono" title={tx.from}>
-												{truncate(tx.from)}
-											</span>
-										</span>
-										<span>
-											<span className="font-medium text-slate-700">To: </span>
-											<span className="font-mono" title={tx.to}>
-												{truncate(tx.to)}
-											</span>
-										</span>
-									</div>
-									<div className="flex justify-between items-center">
-										<span className="font-semibold text-sm tabular-nums text-slate-900">
+										<div className="col-span-2 flex items-center font-mono text-xs text-slate-600 truncate">
+											<span title={tx.from}>{truncate(tx.from)}</span>
+											<CopyButton
+												text={tx.from}
+												label={`Copy from address ${tx.from}`}
+											/>
+										</div>
+										<div className="col-span-2 flex items-center font-mono text-xs text-slate-600 truncate">
+											<span title={tx.to}>{truncate(tx.to)}</span>
+											<CopyButton
+												text={tx.to}
+												label={`Copy to address ${tx.to}`}
+											/>
+										</div>
+										<div className="col-span-2 font-semibold text-sm tabular-nums text-slate-900">
 											{Number(tx.amountXlm).toLocaleString(undefined, {
 												minimumFractionDigits: 2,
 												maximumFractionDigits: 7,
-											})}{" "}
-											XLM
-										</span>
-										<span className="text-xs text-slate-400">
+											})}
+										</div>
+										<div className="col-span-1">
+											<StatusPill status={tx.status} />
+										</div>
+										<div className="col-span-1">
+											<NetworkBadge network={tx.network} />
+										</div>
+										<div className="col-span-1 text-xs text-slate-500">
 											{formatDate(tx.createdAt)}
-										</span>
+										</div>
 									</div>
-									{tx.memo && (
-										<p className="text-xs text-slate-400">Memo: {tx.memo}</p>
-									)}
+
+									{/* Mobile card */}
+									<div className="lg:hidden space-y-2">
+										<div className="flex items-center justify-between">
+											<div className="flex items-center">
+												<span
+													className="font-mono text-xs text-indigo-600"
+													title={tx.hash}
+												>
+													{truncate(tx.hash, 8, 6)}
+												</span>
+												<CopyButton
+													text={tx.hash}
+													label={`Copy transaction hash ${tx.hash}`}
+												/>
+											</div>
+											<div className="flex items-center gap-2">
+												<NetworkBadge network={tx.network} />
+												<StatusPill status={tx.status} />
+											</div>
+										</div>
+										<div className="flex justify-between text-xs text-slate-500">
+											<span className="flex items-center gap-0.5">
+												<span className="font-medium text-slate-700">From: </span>
+												<span className="font-mono" title={tx.from}>
+													{truncate(tx.from)}
+												</span>
+												<CopyButton
+													text={tx.from}
+													label={`Copy from address ${tx.from}`}
+												/>
+											</span>
+											<span className="flex items-center gap-0.5">
+												<span className="font-medium text-slate-700">To: </span>
+												<span className="font-mono" title={tx.to}>
+													{truncate(tx.to)}
+												</span>
+												<CopyButton
+													text={tx.to}
+													label={`Copy to address ${tx.to}`}
+												/>
+											</span>
+										</div>
+										<div className="flex justify-between items-center">
+											<span className="font-semibold text-sm tabular-nums text-slate-900">
+												{Number(tx.amountXlm).toLocaleString(undefined, {
+													minimumFractionDigits: 2,
+													maximumFractionDigits: 7,
+												})}{" "}
+												XLM
+											</span>
+											<span className="text-xs text-slate-400">
+												{formatDate(tx.createdAt)}
+											</span>
+										</div>
+										{tx.memo && (
+											<p className="text-xs text-slate-400">Memo: {tx.memo}</p>
+										)}
+									</div>
 								</div>
+							))
+						) : (
+							<div className="p-12 text-center">
+								<div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-slate-100 mb-3">
+									<Search size={20} className="text-slate-400" aria-hidden />
+								</div>
+								<h3 className="text-sm font-medium text-slate-900">
+									No transactions found
+								</h3>
+								<p className="text-sm text-slate-500 mt-1">
+									No results for current filters.
+								</p>
+								<button
+									type="button"
+									onClick={clearFilters}
+									className="mt-4 text-sm text-indigo-600 font-medium hover:text-indigo-700"
+								>
+									Clear all filters
+								</button>
 							</div>
-						))
-					) : (
-						<div className="p-12 text-center">
-							<div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-slate-100 mb-3">
-								<Search size={20} className="text-slate-400" />
+						)}
+					</div>
+
+					{/* Pagination */}
+					{sortedData.length > 0 && (
+						<div className="border-t border-slate-100 p-4 flex flex-col sm:flex-row items-center justify-between gap-4 bg-slate-50/50">
+							<span className="text-xs text-slate-500">
+								Showing{" "}
+								<span className="font-medium text-slate-700">
+									{(currentPage - 1) * itemsPerPage + 1}
+								</span>{" "}
+								–{" "}
+								<span className="font-medium text-slate-700">
+									{Math.min(currentPage * itemsPerPage, sortedData.length)}
+								</span>{" "}
+								of{" "}
+								<span className="font-medium text-slate-700">
+									{sortedData.length}
+								</span>{" "}
+								results
+							</span>
+
+							<div className="flex items-center gap-1 select-none">
+								<button
+									type="button"
+									onClick={() => handlePageChange(currentPage - 1)}
+									disabled={currentPage === 1}
+									className="p-1.5 rounded-md hover:bg-white hover:shadow-sm border border-transparent hover:border-slate-200 text-slate-400 hover:text-slate-600 disabled:opacity-30 transition-all"
+									aria-label="Previous page"
+								>
+									<ChevronLeft size={16} aria-hidden />
+								</button>
+
+								{Array.from({ length: totalPages }, (_, i) => i + 1).map(
+									(page) => (
+										<button
+											key={page}
+											type="button"
+											onClick={() => handlePageChange(page)}
+											aria-current={currentPage === page ? "page" : undefined}
+											className={`w-7 h-7 rounded text-xs font-medium transition-all ${
+												currentPage === page
+													? "bg-white border border-slate-200 shadow-sm text-indigo-600"
+													: "text-slate-600 hover:bg-white hover:shadow-sm"
+											}`}
+										>
+											{page}
+										</button>
+									),
+								)}
+
+								<button
+									type="button"
+									onClick={() => handlePageChange(currentPage + 1)}
+									disabled={currentPage === totalPages}
+									className="p-1.5 rounded-md hover:bg-white hover:shadow-sm border border-transparent hover:border-slate-200 text-slate-400 hover:text-slate-600 disabled:opacity-30 transition-all"
+									aria-label="Next page"
+								>
+									<ChevronRight size={16} aria-hidden />
+								</button>
 							</div>
-							<h3 className="text-sm font-medium text-slate-900">
-								No transactions found
-							</h3>
-							<p className="text-sm text-slate-500 mt-1">
-								No results for current filters.
-							</p>
-							<button
-								onClick={clearFilters}
-								className="mt-4 text-sm text-indigo-600 font-medium hover:text-indigo-700"
-							>
-								Clear all filters
-							</button>
 						</div>
 					)}
 				</div>
-
-				{/* Pagination */}
-				{sortedData.length > 0 && (
-					<div className="border-t border-slate-100 p-4 flex flex-col sm:flex-row items-center justify-between gap-4 bg-slate-50/50">
-						<span className="text-xs text-slate-500">
-							Showing{" "}
-							<span className="font-medium text-slate-700">
-								{(currentPage - 1) * itemsPerPage + 1}
-							</span>{" "}
-							–{" "}
-							<span className="font-medium text-slate-700">
-								{Math.min(currentPage * itemsPerPage, sortedData.length)}
-							</span>{" "}
-							of{" "}
-							<span className="font-medium text-slate-700">
-								{sortedData.length}
-							</span>{" "}
-							results
-						</span>
-
-						<div className="flex items-center gap-1 select-none">
-							<button
-								onClick={() => handlePageChange(currentPage - 1)}
-								disabled={currentPage === 1}
-								className="p-1.5 rounded-md hover:bg-white hover:shadow-sm border border-transparent hover:border-slate-200 text-slate-400 hover:text-slate-600 disabled:opacity-30 transition-all"
-								aria-label="Previous page"
-							>
-								<ChevronLeft size={16} />
-							</button>
-
-							{Array.from({ length: totalPages }, (_, i) => i + 1).map(
-								(page) => (
-									<button
-										key={page}
-										onClick={() => handlePageChange(page)}
-										className={`w-7 h-7 rounded text-xs font-medium transition-all ${
-											currentPage === page
-												? "bg-white border border-slate-200 shadow-sm text-indigo-600"
-												: "text-slate-600 hover:bg-white hover:shadow-sm"
-										}`}
-									>
-										{page}
-									</button>
-								),
-							)}
-
-							<button
-								onClick={() => handlePageChange(currentPage + 1)}
-								disabled={currentPage === totalPages}
-								className="p-1.5 rounded-md hover:bg-white hover:shadow-sm border border-transparent hover:border-slate-200 text-slate-400 hover:text-slate-600 disabled:opacity-30 transition-all"
-								aria-label="Next page"
-							>
-								<ChevronRight size={16} />
-							</button>
-						</div>
-					</div>
-				)}
-			</div>
+			)}
 		</div>
 	);
 }


### PR DESCRIPTION
…py-to-clipboard

- #253: add TransactionsTableSkeleton with isLoading prop (role=status, aria-busy)
- #254: tighten responsive breakpoints (sm:flex-row, fluid padding p-4→md:p-8)
- #255: keyboard navigation for sortable columns (tabIndex, Enter/Space, aria-sort)
- #256: CopyButton on hash/from/to using useCopyToClipboard (Copy→Check icon feedback)

Tests: 22 tests covering all four features, no new regressions
closes #253 
closes #254 
closes #255 
closes #256 