### PR TITLE
feat(auth): add toast feedback, Storybook story, and JSDoc for login …

### DIFF
--- a/src/app/login/Login.stories.tsx
+++ b/src/app/login/Login.stories.tsx
@@ -1,0 +1,322 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ToastContainer } from "@/components/ui/Toast";
+import type { ToastMessage } from "@/components/ui/Toast";
+
+// ---------------------------------------------------------------------------
+// LoginErrorCard — extracted for isolated story rendering
+// ---------------------------------------------------------------------------
+
+function LoginErrorCard({
+	message,
+	onDismiss,
+}: {
+	message: string;
+	onDismiss: () => void;
+}) {
+	return (
+		<div
+			role="alert"
+			className="flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+		>
+			<svg
+				className="mt-0.5 h-4 w-4 shrink-0 text-red-500"
+				fill="none"
+				viewBox="0 0 24 24"
+				strokeWidth={2}
+				stroke="currentColor"
+				aria-hidden="true"
+			>
+				<path
+					strokeLinecap="round"
+					strokeLinejoin="round"
+					d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+				/>
+			</svg>
+			<span className="flex-1">{message}</span>
+			<button
+				type="button"
+				onClick={onDismiss}
+				aria-label="Dismiss error"
+				className="text-red-400 hover:text-red-600"
+			>
+				<svg
+					className="h-4 w-4"
+					fill="none"
+					viewBox="0 0 24 24"
+					strokeWidth={2}
+					stroke="currentColor"
+					aria-hidden="true"
+				>
+					<path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+				</svg>
+			</button>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// LoginWelcomeHint
+// ---------------------------------------------------------------------------
+
+function LoginWelcomeHint() {
+	return (
+		<div className="rounded-lg border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-blue-700">
+			<p className="font-medium">Welcome to Mux Protocol</p>
+			<p className="mt-0.5 text-blue-600">
+				Enter your credentials to access your developer console.
+			</p>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Composed login card shell for story use
+// ---------------------------------------------------------------------------
+
+function LoginCard({ children }: { children: React.ReactNode }) {
+	return (
+		<div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+			<div className="w-full max-w-md">
+				<div className="mb-8 text-center">
+					<div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-purple-600">
+						<svg
+							className="h-6 w-6 text-white"
+							fill="none"
+							viewBox="0 0 24 24"
+							strokeWidth={2}
+							stroke="currentColor"
+							aria-hidden="true"
+						>
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
+							/>
+						</svg>
+					</div>
+					<h1 className="text-2xl font-bold tracking-tight text-gray-900">Mux Protocol</h1>
+					<p className="mt-1 text-sm text-gray-500">Sign in to your developer console</p>
+				</div>
+				<div className="rounded-2xl border border-gray-200 bg-white px-8 py-10 shadow-sm">
+					<h2 className="mb-6 text-lg font-semibold text-gray-900">Sign in</h2>
+					{children}
+				</div>
+				<p className="mt-6 text-center text-xs text-gray-400">
+					Mux Protocol developer console — internal use only
+				</p>
+			</div>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Meta
+// ---------------------------------------------------------------------------
+
+/**
+ * Stories for the auth/login page components.
+ *
+ * Covers:
+ * - Default (empty/pristine) state with welcome hint
+ * - Error state with inline error card
+ * - Submitting state with loading button
+ * - Toast feedback on success and on failure
+ */
+const meta = {
+	title: "Auth/Login",
+	component: LoginCard,
+	parameters: { layout: "fullscreen" },
+	tags: ["autodocs"],
+} satisfies Meta<typeof LoginCard>;
+
+export default meta;
+type Story = StoryObj<typeof LoginCard>;
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+/** Pristine form: user hasn't typed anything yet. Shows the welcome hint. */
+export const Default: Story = {
+	render: () => (
+		<LoginCard>
+			<LoginWelcomeHint />
+			<form noValidate aria-label="Sign in form">
+				<div className="mb-4">
+					<label htmlFor="email" className="mb-1.5 block text-sm font-medium text-gray-700">
+						Email address
+					</label>
+					<input
+						id="email"
+						name="email"
+						type="email"
+						placeholder="you@example.com"
+						className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+					/>
+				</div>
+				<div className="mb-6">
+					<label htmlFor="password" className="mb-1.5 block text-sm font-medium text-gray-700">
+						Password
+					</label>
+					<input
+						id="password"
+						name="password"
+						type="password"
+						placeholder="••••••••"
+						className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+					/>
+				</div>
+				<button
+					type="submit"
+					className="flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+				>
+					Sign in
+				</button>
+			</form>
+		</LoginCard>
+	),
+};
+
+/** Form with a submit error displayed via the inline error card. */
+export const WithError: Story = {
+	render: () => (
+		<LoginCard>
+			<LoginErrorCard
+				message="Sign in failed. Please check your credentials and try again."
+				onDismiss={() => {}}
+			/>
+			<form noValidate aria-label="Sign in form">
+				<div className="mb-4">
+					<label htmlFor="email" className="mb-1.5 block text-sm font-medium text-gray-700">
+						Email address
+					</label>
+					<input
+						id="email"
+						name="email"
+						type="email"
+						defaultValue="wrong@example.com"
+						className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+					/>
+				</div>
+				<div className="mb-6">
+					<label htmlFor="password" className="mb-1.5 block text-sm font-medium text-gray-700">
+						Password
+					</label>
+					<input
+						id="password"
+						name="password"
+						type="password"
+						placeholder="••••••••"
+						className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+					/>
+				</div>
+				<button
+					type="submit"
+					className="flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-blue-700"
+				>
+					Sign in
+				</button>
+			</form>
+		</LoginCard>
+	),
+};
+
+/** Submitting state — button disabled with spinner. */
+export const Submitting: Story = {
+	render: () => (
+		<LoginCard>
+			<form noValidate aria-label="Sign in form">
+				<div className="mb-4">
+					<label htmlFor="email" className="mb-1.5 block text-sm font-medium text-gray-700">
+						Email address
+					</label>
+					<input
+						id="email"
+						name="email"
+						type="email"
+						defaultValue="dev@muxprotocol.io"
+						disabled
+						className="block w-full rounded-lg border border-gray-300 bg-gray-50 px-3 py-2.5 text-sm text-gray-500 cursor-not-allowed"
+					/>
+				</div>
+				<div className="mb-6">
+					<label htmlFor="password" className="mb-1.5 block text-sm font-medium text-gray-700">
+						Password
+					</label>
+					<input
+						id="password"
+						name="password"
+						type="password"
+						defaultValue="••••••••"
+						disabled
+						className="block w-full rounded-lg border border-gray-300 bg-gray-50 px-3 py-2.5 text-sm text-gray-500 cursor-not-allowed"
+					/>
+				</div>
+				<button
+					type="submit"
+					disabled
+					className="flex w-full items-center justify-center gap-2 rounded-lg bg-blue-400 px-4 py-2.5 text-sm font-semibold text-white cursor-not-allowed opacity-60"
+				>
+					<svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+						<circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+						<path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+					</svg>
+					Signing in…
+				</button>
+			</form>
+		</LoginCard>
+	),
+};
+
+/** Toast feedback — success notification after sign-in. */
+export const ToastSuccess: Story = {
+	render: () => {
+		const toasts: ToastMessage[] = [
+			{ id: "1", type: "success", message: "Signed in successfully!", description: "Welcome back, Alex." },
+		];
+		return (
+			<div className="relative">
+				<ToastContainer toasts={toasts} onDismiss={() => {}} position="top-right" />
+				<LoginCard>
+					<div className="py-4 text-center text-sm text-gray-500">Redirecting to dashboard…</div>
+				</LoginCard>
+			</div>
+		);
+	},
+};
+
+/** Toast feedback — error notification after failed sign-in. */
+export const ToastError: Story = {
+	render: () => {
+		const toasts: ToastMessage[] = [
+			{ id: "1", type: "error", message: "Sign in failed", description: "Invalid email or password." },
+		];
+		return (
+			<div className="relative">
+				<ToastContainer toasts={toasts} onDismiss={() => {}} position="top-right" />
+				<LoginCard>
+					<LoginErrorCard message="Invalid email or password." onDismiss={() => {}} />
+					<form noValidate>
+						<div className="mb-4">
+							<input
+								type="email"
+								placeholder="you@example.com"
+								className="block w-full rounded-lg border border-red-400 bg-red-50 px-3 py-2.5 text-sm"
+							/>
+						</div>
+						<div className="mb-6">
+							<input
+								type="password"
+								placeholder="••••••••"
+								className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2.5 text-sm"
+							/>
+						</div>
+						<button type="submit" className="flex w-full justify-center rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white">
+							Sign in
+						</button>
+					</form>
+				</LoginCard>
+			</div>
+		);
+	},
+};

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { type FormEvent, Suspense, useEffect, useState } from "react";
 import { AuthLoadingSkeleton } from "@/components/layouts/AuthLoadingSkeleton";
 import { useAuth } from "@/context/AuthContext";
+import { ToastContainer, useToast } from "@/components/ui/Toast";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -23,6 +24,14 @@ interface FieldErrors {
 // API call — #325: wire to backend via POST /api/auth/login
 // ---------------------------------------------------------------------------
 
+/**
+ * Sends login credentials to the backend and returns the authenticated user.
+ *
+ * @param email - The user's email address.
+ * @param password - The user's password (plaintext; HTTPS in production).
+ * @returns The authenticated user record `{ name, email, role }`.
+ * @throws {Error} When the response is not OK or the user payload is missing.
+ */
 async function authenticateUser(
 	email: string,
 	password: string,
@@ -74,6 +83,12 @@ function validate(fields: LoginFormState): FieldErrors {
 // #327: Styled error card component
 // ---------------------------------------------------------------------------
 
+/**
+ * Inline error banner displayed below the page header when a submit error occurs.
+ *
+ * @param message - The error text to display.
+ * @param onDismiss - Callback invoked when the user clicks the dismiss (×) button.
+ */
 function LoginErrorCard({
 	message,
 	onDismiss,
@@ -131,6 +146,10 @@ function LoginErrorCard({
 // #326: Empty/welcome state shown before the user starts typing
 // ---------------------------------------------------------------------------
 
+/**
+ * Informational banner shown when the login form is in its pristine (untouched) state.
+ * Disappears as soon as the user begins entering credentials or a submit error appears.
+ */
 function LoginWelcomeHint() {
 	return (
 		<div
@@ -153,6 +172,7 @@ function LoginPageContent() {
 	const { isAuthenticated, isLoading, signIn } = useAuth();
 	const router = useRouter();
 	const searchParams = useSearchParams();
+	const { toasts, addToast, dismissToast } = useToast();
 
 	const [fields, setFields] = useState<LoginFormState>({
 		email: "",
@@ -197,13 +217,15 @@ function LoginPageContent() {
 		try {
 			const user = await authenticateUser(fields.email, fields.password);
 			signIn(user);
+			addToast({ type: "success", message: "Signed in successfully!", description: `Welcome back, ${user.name}.` });
 			router.replace(callbackUrl);
 		} catch (err) {
-			setSubmitError(
+			const message =
 				err instanceof Error
 					? err.message
-					: "Sign in failed. Please check your credentials and try again.",
-			);
+					: "Sign in failed. Please check your credentials and try again.";
+			setSubmitError(message);
+			addToast({ type: "error", message: "Sign in failed", description: message });
 		} finally {
 			setIsSubmitting(false);
 		}
@@ -217,6 +239,7 @@ function LoginPageContent() {
 
 	return (
 		<div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+			<ToastContainer toasts={toasts} onDismiss={dismissToast} position="top-right" />
 			<div className="w-full max-w-md">
 				{/* Logo / brand */}
 				<div className="mb-8 text-center">

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -9,8 +9,11 @@ import {
 } from "react";
 
 export interface AuthUser {
+	/** The user's display name */
 	name: string;
+	/** The user's email address */
 	email: string;
+	/** The user's role, e.g. "admin" or "developer" */
 	role: string;
 }
 
@@ -22,10 +25,19 @@ interface SessionRecord {
 }
 
 interface AuthContextValue {
+	/** The currently authenticated user, or null if not signed in. */
 	user: AuthUser | null;
+	/** True while the session is being rehydrated from storage on mount. */
 	isLoading: boolean;
+	/** True when a valid, non-expired session exists. */
 	isAuthenticated: boolean;
+	/**
+	 * Persist the authenticated user and start a session.
+	 * @param user - The authenticated user object returned by the API.
+	 * @param ttlMs - Session lifetime in milliseconds. Defaults to 8 hours.
+	 */
 	signIn: (user: AuthUser, ttlMs?: number) => void;
+	/** Clear the session and sign the user out. */
 	signOut: () => void;
 }
 
@@ -59,6 +71,20 @@ function clearSessionCookie(): void {
 // Provider
 // ---------------------------------------------------------------------------
 
+/**
+ * Provides authentication state and actions to the component tree.
+ *
+ * On mount it rehydrates the session from `sessionStorage` and validates the
+ * expiry timestamp. Place this at the root of the application so all
+ * descendants can call `useAuth()`.
+ *
+ * @example
+ * ```tsx
+ * <AuthProvider>
+ *   <App />
+ * </AuthProvider>
+ * ```
+ */
 export function AuthProvider({ children }: { children: React.ReactNode }) {
 	const [user, setUser] = useState<AuthUser | null>(null);
 	const [isLoading, setIsLoading] = useState(true);
@@ -131,6 +157,19 @@ export const SessionProvider = AuthProvider;
 // Hook
 // ---------------------------------------------------------------------------
 
+/**
+ * Returns the current auth context value.
+ *
+ * Must be called inside an `AuthProvider` (or its `SessionProvider` alias).
+ * Throws if used outside of the provider.
+ *
+ * @returns `{ user, isLoading, isAuthenticated, signIn, signOut }`
+ *
+ * @example
+ * ```tsx
+ * const { user, signOut } = useAuth();
+ * ```
+ */
 export function useAuth(): AuthContextValue {
 	const ctx = useContext(AuthContext);
 	if (!ctx) {


### PR DESCRIPTION
closes #333, 

closes #334, 

closes #335


- Imported `useToast` and `ToastContainer` from `src/components/ui/Toast.tsx` into `src/app/login/page.tsx`.
- Called `addToast({ type: 'success', ... })` after `signIn()` succeeds, showing the user's name in the description before the redirect fires.
- Called `addToast({ type: 'error', ... })` in the catch block alongside the existing inline `LoginErrorCard`, so both feedback surfaces are active.
- Rendered `<ToastContainer>` at the top of the page JSX with `position="top-right"`.

**Files changed:**
- `src/app/login/page.tsx`

---

### #334 — Auth & login: Add Storybook story

**Problem:** No Storybook stories existed for the login page, making it impossible to visually develop and review the login UI in isolation.

**Solution:**
Created `src/app/login/Login.stories.tsx` with the following stories:

| Story | What it shows |
|-------|---------------|
| `Default` | Pristine form with `LoginWelcomeHint` banner | | `WithError` | Form in error state with `LoginErrorCard` | | `Submitting` | Button disabled with spinner animation | | `ToastSuccess` | `ToastContainer` success toast overlaying the card | | `ToastError` | `ToastContainer` error toast alongside inline error |

The story file is self-contained — it replicates the internal sub-components (`LoginErrorCard`, `LoginWelcomeHint`, `LoginCard`) locally so the stories do not depend on Next.js router context (which Storybook cannot provide). The `title` is `"Auth/Login"`, tagged with `autodocs`.

**Files changed:**
- `src/app/login/Login.stories.tsx` (new file)

---

### #335 — Auth & login: Document props usage

**Problem:** The auth/login components lacked JSDoc, making it hard for contributors to understand what each prop, parameter, and return value does without reading the full implementation.

**Solution:**
Added JSDoc comments to every public/exported interface, function, and component across the login module:

- `AuthUser` — field-level JSDoc on `name`, `email`, `role`.
- `AuthContextValue` — field-level JSDoc on `user`, `isLoading`, `isAuthenticated`, `signIn` (with `@param` tags), `signOut`.
- `AuthProvider` — component-level JSDoc with usage example.
- `useAuth` — hook-level JSDoc with `@returns` and usage example.
- `authenticateUser` — function-level JSDoc with `@param` and `@throws`.
- `LoginErrorCard` — component-level JSDoc with `@param message` and `@param onDismiss`.
- `LoginWelcomeHint` — component-level JSDoc describing when it appears.

**Files changed:**
- `src/context/AuthContext.tsx`
- `src/app/login/page.tsx`

---

Closes #333
Closes #334
Closes #335