### PR TITLE
feat(wallet-detail): mobile layout polish and analytics tracking (#247, #248)

### DIFF
--- a/src/components/wallet/WalletDetail.tsx
+++ b/src/components/wallet/WalletDetail.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { Check, Copy, RefreshCw } from "lucide-react";
-import { useId } from "react";
+import { AlertCircle, Check, Copy, RefreshCw } from "lucide-react";
+import { useCallback, useId } from "react";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { ErrorState } from "@/components/ui/ErrorState";
 import { Skeleton, WalletDetailSkeleton } from "@/components/ui/Skeleton";
 import { NetworkBadge } from "@/components/wallet/NetworkBadge";
 import { StatusIndicator } from "@/components/wallet/StatusIndicator";
+import { useAnalyticsTracking } from "@/hooks/useAnalyticsTracking";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { useWalletBalance } from "@/hooks/useWalletBalance";
+import { trackWalletEvent } from "@/services/walletAnalyticsTracking";
 import { truncateAddress } from "@/utils/addressFormatting";
 import { formatDate } from "@/utils/dateFormatting";
 
@@ -20,13 +22,29 @@ interface WalletDetailProps {
 export function WalletDetail({ id }: WalletDetailProps) {
 	const { wallet, balance, loading, error, lastUpdated, refresh } =
 		useWalletBalance(id);
-	const { copy, copied } = useCopyToClipboard();
+	const { copy, copied, error: copyError } = useCopyToClipboard();
+	const { track } = useAnalyticsTracking("wallet_detail");
 	const balanceHeadingId = useId();
 	const infoHeadingId = useId();
 
 	const isNotFound =
 		!!error &&
 		(error.toLowerCase().includes("not found") || error === "not_found");
+
+	const handleRefresh = useCallback(() => {
+		trackWalletEvent("wallet_balance_refresh", { walletId: id });
+		track("wallet_balance_refresh", { walletId: id });
+		refresh();
+	}, [id, track, refresh]);
+
+	const handleCopy = useCallback(
+		(address: string) => {
+			trackWalletEvent("wallet_address_copied", { walletId: id });
+			track("wallet_address_copied", { walletId: id });
+			copy(address);
+		},
+		[id, track, copy],
+	);
 
 	if (isNotFound) {
 		return (
@@ -69,20 +87,26 @@ export function WalletDetail({ id }: WalletDetailProps) {
 	return (
 		<div className="space-y-4 sm:space-y-6">
 			{/* Balance card */}
-			<div className="rounded-xl border border-zinc-200 bg-white p-4 sm:p-6 dark:border-zinc-800 dark:bg-zinc-900">
+			<section
+				aria-labelledby={balanceHeadingId}
+				className="rounded-xl border border-zinc-200 bg-white p-4 sm:p-6 dark:border-zinc-800 dark:bg-zinc-900"
+			>
 				<div className="mb-4 flex flex-wrap items-center justify-between gap-2">
-					<h2 className="text-sm font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+					<h2
+						id={balanceHeadingId}
+						className="text-sm font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400"
+					>
 						Live Balance
 					</h2>
-					<div className="flex items-center gap-2">
+					<div className="flex shrink-0 items-center gap-2">
 						{lastUpdated && (
-							<span className="text-xs text-zinc-400 dark:text-zinc-500">
+							<span className="min-w-0 truncate text-xs text-zinc-400 dark:text-zinc-500">
 								Updated {formatDate(lastUpdated)}
 							</span>
 						)}
 						<button
 							type="button"
-							onClick={refresh}
+							onClick={handleRefresh}
 							disabled={loading}
 							aria-label="Refresh balance"
 							className="rounded-md p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600 disabled:opacity-50 dark:hover:bg-zinc-800 dark:hover:text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
@@ -115,8 +139,14 @@ export function WalletDetail({ id }: WalletDetailProps) {
 
 			{/* Wallet metadata */}
 			{wallet ? (
-				<div className="rounded-xl border border-zinc-200 bg-white p-4 sm:p-6 dark:border-zinc-800 dark:bg-zinc-900">
-					<h2 className="mb-4 text-sm font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+				<section
+					aria-labelledby={infoHeadingId}
+					className="rounded-xl border border-zinc-200 bg-white p-4 sm:p-6 dark:border-zinc-800 dark:bg-zinc-900"
+				>
+					<h2
+						id={infoHeadingId}
+						className="mb-4 text-sm font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400"
+					>
 						Wallet Info
 					</h2>
 					<dl className="space-y-4">
@@ -131,16 +161,36 @@ export function WalletDetail({ id }: WalletDetailProps) {
 								<Button
 									variant="ghost"
 									size="icon-sm"
-									onClick={() => copy(wallet.address)}
-									aria-label={copied ? "Address copied" : "Copy wallet address"}
-									title={copied ? "Copied!" : "Copy address"}
+									onClick={() => handleCopy(wallet.address)}
+									disabled={!!copyError}
+									aria-label={
+										copyError
+											? copyError
+											: copied
+												? "Address copied"
+												: "Copy wallet address"
+									}
+									title={
+										copyError
+											? copyError
+											: copied
+												? "Copied!"
+												: "Copy address"
+									}
 								>
-									{copied ? (
+									{copyError ? (
+										<AlertCircle className="h-4 w-4 text-red-500" aria-hidden="true" />
+									) : copied ? (
 										<Check className="h-4 w-4 text-green-500" aria-hidden="true" />
 									) : (
 										<Copy className="h-4 w-4" aria-hidden="true" />
 									)}
 								</Button>
+								{copyError && (
+									<p role="alert" className="sr-only">
+										{copyError}
+									</p>
+								)}
 							</dd>
 						</div>
 						<div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">

--- a/src/services/walletAnalyticsTracking.test.ts
+++ b/src/services/walletAnalyticsTracking.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { trackWalletEvent } from "./walletAnalyticsTracking";
+
+describe("trackWalletEvent", () => {
+	const originalEnv = process.env.NODE_ENV;
+
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		process.env.NODE_ENV = originalEnv;
+	});
+
+	it("logs to console in development environment", () => {
+		process.env.NODE_ENV = "development";
+		const consoleSpy = vi
+			.spyOn(console, "log")
+			.mockImplementation(() => {});
+
+		trackWalletEvent("wallet_detail_view", { walletId: "wallet-001" });
+
+		expect(consoleSpy).toHaveBeenCalledTimes(1);
+		expect(consoleSpy).toHaveBeenCalledWith(
+			"[Analytics] wallet_detail_view",
+			{ walletId: "wallet-001" },
+		);
+
+		consoleSpy.mockRestore();
+	});
+
+	it("does not log in production environment", () => {
+		process.env.NODE_ENV = "production";
+		const consoleSpy = vi
+			.spyOn(console, "log")
+			.mockImplementation(() => {});
+
+		trackWalletEvent("wallet_detail_view", { walletId: "wallet-001" });
+
+		expect(consoleSpy).not.toHaveBeenCalled();
+
+		consoleSpy.mockRestore();
+	});
+
+	it("does not log in test environment", () => {
+		process.env.NODE_ENV = "test";
+		const consoleSpy = vi
+			.spyOn(console, "log")
+			.mockImplementation(() => {});
+
+		trackWalletEvent("wallet_balance_refresh", { walletId: "wallet-001" });
+
+		expect(consoleSpy).not.toHaveBeenCalled();
+
+		consoleSpy.mockRestore();
+	});
+
+	it("accepts all known event names without throwing", () => {
+		const events: Array<{
+			name: Parameters<typeof trackWalletEvent>[0];
+			payload: Parameters<typeof trackWalletEvent>[1];
+		}> = [
+			{ name: "wallet_detail_view", payload: { walletId: "wallet-001" } },
+			{ name: "wallet_balance_refresh", payload: { walletId: "wallet-001" } },
+			{ name: "wallet_address_copied", payload: { walletId: "wallet-001" } },
+			{ name: "wallet_send_opened", payload: { walletId: "wallet-001" } },
+			{ name: "wallet_receive_opened", payload: { walletId: "wallet-001" } },
+		];
+
+		for (const { name, payload } of events) {
+			expect(() => trackWalletEvent(name, payload)).not.toThrow();
+		}
+	});
+
+	it("defaults payload to empty object when omitted", () => {
+		process.env.NODE_ENV = "development";
+		const consoleSpy = vi
+			.spyOn(console, "log")
+			.mockImplementation(() => {});
+
+		trackWalletEvent("wallet_detail_view");
+
+		expect(consoleSpy).toHaveBeenCalledWith(
+			"[Analytics] wallet_detail_view",
+			{},
+		);
+
+		consoleSpy.mockRestore();
+	});
+});

--- a/src/services/walletAnalyticsTracking.ts
+++ b/src/services/walletAnalyticsTracking.ts
@@ -1,0 +1,55 @@
+/**
+ * Analytics tracking stub for the Wallet Detail UI.
+ *
+ * Provides a lightweight, typed event-tracking interface that can be swapped
+ * for a real analytics SDK (e.g. Segment, PostHog, Amplitude) without changing
+ * call sites. In development the stubs log to the console; in production they
+ * are no-ops until a real provider is wired in.
+ *
+ * Usage:
+ *   import { trackWalletEvent } from "@/services/walletAnalyticsTracking";
+ *   trackWalletEvent("wallet_detail_view", { walletId: "wallet-001" });
+ */
+
+// ---------------------------------------------------------------------------
+// Event names (enumerate here for discoverability)
+// ---------------------------------------------------------------------------
+
+export type WalletEventName =
+	| "wallet_detail_view"
+	| "wallet_balance_refresh"
+	| "wallet_address_copied"
+	| "wallet_send_opened"
+	| "wallet_receive_opened";
+
+// ---------------------------------------------------------------------------
+// Payload type
+// ---------------------------------------------------------------------------
+
+export type WalletEventPayload = Record<string, unknown>;
+
+// ---------------------------------------------------------------------------
+// Stub track function
+// ---------------------------------------------------------------------------
+
+/**
+ * Record a wallet-related analytics event.
+ *
+ * In development this logs to the console so you can verify tracking calls
+ * during manual testing. In production it becomes a no-op until a real
+ * analytics provider adapter is implemented.
+ */
+export function trackWalletEvent(
+	eventName: WalletEventName,
+	payload: WalletEventPayload = {},
+): void {
+	if (process.env.NODE_ENV === "development") {
+		// biome-ignore lint/suspicious/noConsoleLog: allowed in dev
+		console.log(`[Analytics] ${eventName}`, payload);
+	}
+
+	// TODO: Replace with real analytics provider integration, e.g.:
+	//   if (typeof window !== "undefined" && window.analytics) {
+	//     window.analytics.track(eventName, payload);
+	//   }
+}


### PR DESCRIPTION
## Summary

Closes #247, closes #248.

### #247 — Mobile layout polish

- **Fixed malformed JSX**: the balance card and wallet-info card were opened as `<div>` but closed as `</section>`, producing invalid HTML. Both containers are now proper `<section>` elements.
- **Wired accessibility IDs**: `balanceHeadingId` and `infoHeadingId` (created with `useId` but previously unused) are now applied as `id` on each `<h2>` and `aria-labelledby` on the wrapping `<section>`, making each card a named landmark region.
- **Refresh-button group**: added `shrink-0` so the icon button and timestamp never wrap behind each other on narrow viewports.
- **Timestamp overflow**: added `min-w-0 truncate` to the "Updated …" span so it clips gracefully instead of forcing a layout overflow on small screens.

### #248 — Analytics tracking stub

- **New `src/services/walletAnalyticsTracking.ts`**: typed `WalletEventName` union (`wallet_detail_view`, `wallet_balance_refresh`, `wallet_address_copied`, `wallet_send_opened`, `wallet_receive_opened`) and a `trackWalletEvent` stub that logs in `development` and is a no-op in `production` until a real provider is wired in. Matches the pattern already established in `analyticsTracking.ts` for transactions.
- **New `src/services/walletAnalyticsTracking.test.ts`**: full test suite mirroring `analyticsTracking.test.ts` — dev logs, prod/test no-ops, all known event names, default empty payload.
- **`WalletDetail` integration**: uses `useAnalyticsTracking("wallet_detail")` for an automatic `page_view` on mount; calls `trackWalletEvent` + `track` on balance refresh and address copy interactions.
- **Clipboard error surface**: `copyError` from `useCopyToClipboard` is now reflected in the copy button (`disabled`, `aria-label`, `AlertCircle` icon) and a `sr-only` alert element, fulfilling the behaviour covered by the existing clipboard test suite.

## Test plan

- [ ] `walletAnalyticsTracking.test.ts` — new file, covers dev log, prod no-op, test no-op, all event names, default payload
- [ ] `WalletDetail.responsive.test.tsx` — existing; validates `p-4 sm:p-6`, `flex-col sm:flex-row`, `text-3xl sm:text-4xl`, `min-w-0 truncate` on address code, `space-y-4 sm:space-y-6`
- [ ] `WalletDetail.clipboard.test.tsx` — existing; validates copy button renders, copies full address, aria-label update, error state (alert + disabled button)
- [ ] `WalletDetail.test.tsx` — existing; validates balance render, metadata, refresh button, skeleton, error states