### PR TITLE
Feat/267 spending limits error state

### DIFF
--- a/src/components/dashboard/SpendingLimitsCard.test.tsx
+++ b/src/components/dashboard/SpendingLimitsCard.test.tsx
@@ -1,7 +1,16 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { SpendingLimitsCard } from "./SpendingLimitsCard";
+import {
+	SpendingLimitsCard,
+	SpendingLimitsCardSkeleton,
+	SpendingLimitsEmptyState,
+	SpendingLimitsErrorState,
+} from "./SpendingLimitsCard";
+
+// ---------------------------------------------------------------------------
+// Core card rendering
+// ---------------------------------------------------------------------------
 
 describe("SpendingLimitsCard", () => {
 	it("renders the card title and description", async () => {
@@ -11,90 +20,50 @@ describe("SpendingLimitsCard", () => {
 				screen.getByRole("heading", { name: /spending limits/i }),
 			).toBeInTheDocument();
 		});
-		await waitFor(() => {
-			expect(
-				screen.getByText(/control your api expenditure/i),
-			).toBeInTheDocument();
-		});
+		expect(screen.getByText(/control your api expenditure/i)).toBeInTheDocument();
 	});
 
-	it("renders the Active badge", async () => {
+	it("renders the Active badge", () => {
 		render(<SpendingLimitsCard />);
-		await waitFor(() => {
-			expect(screen.getByText("Active")).toBeInTheDocument();
-		});
+		expect(screen.getByText("Active")).toBeInTheDocument();
 	});
 
-	it("renders the daily usage section with default values", async () => {
+	it("renders daily usage section with default values", () => {
 		render(<SpendingLimitsCard />);
-		await waitFor(() => {
-			expect(screen.getByText("$750")).toBeInTheDocument();
-		});
-		await waitFor(() => {
-			expect(screen.getByText("/ $5000")).toBeInTheDocument();
-		});
-		await waitFor(() => {
-			expect(screen.getByText("15.0%")).toBeInTheDocument();
-		});
-	});
-
-	it("renders both input fields with default values", async () => {
-		render(<SpendingLimitsCard />);
-		await waitFor(() => {
-			const dailyInput = screen.getByRole("spinbutton", {
-				name: /daily spending limit/i,
-			});
-			expect(dailyInput).toHaveValue(5000);
-		});
-		await waitFor(() => {
-			const txInput = screen.getByRole("spinbutton", {
-				name: /per-transaction limit/i,
-			});
-			expect(txInput).toHaveValue(1000);
-		});
-	});
-
-	it("renders the Save Settings button", async () => {
-		render(<SpendingLimitsCard />);
-		await waitFor(() => {
-			expect(
-				screen.getByRole("button", { name: /save settings/i }),
-			).toBeInTheDocument();
-		});
-	});
-
-	it("renders the policy note", async () => {
-		render(<SpendingLimitsCard />);
-		await waitFor(() => {
-			expect(
-				screen.getByText(/spending limits are enforced in real-time/i),
-			).toBeInTheDocument();
-		});
-	});
-
-	it("updates daily limit when input changes", async () => {
-		const user = userEvent.setup();
-		render(<SpendingLimitsCard />);
-
-		const dailyInput = screen.getByRole("spinbutton", {
-			name: /daily spending limit/i,
-		});
-		await user.clear(dailyInput);
-		await user.type(dailyInput, "10000");
-
-		expect(dailyInput).toHaveValue(10000);
-	});
-
-	it("updates the usage percentage when daily limit changes", async () => {
-		const user = userEvent.setup();
-		render(<SpendingLimitsCard />);
-
-		// Default: 750 / 5000 = 15%
+		expect(screen.getByText("$750")).toBeInTheDocument();
+		expect(screen.getByText("/ $5000")).toBeInTheDocument();
 		expect(screen.getByText("15.0%")).toBeInTheDocument();
+	});
 
-		const dailyInput = screen.getByRole("spinbutton", {
-			name: /daily spending limit/i,
-		});
+	it("renders both input fields with default values", () => {
+		render(<SpendingLimitsCard />);
+		expect(
+			screen.getByRole("spinbutton", { name: /daily spending limit/i }),
+		).toHaveValue(5000);
+		expect(
+			screen.getByRole("spinbutton", { name: /per-transaction limit/i }),
+		).toHaveValue(1000);
+	});
+
+	it("renders the Save Settings button", () => {
+		render(<SpendingLimitsCard />);
+		expect(
+			screen.getByRole("button", { name: /save settings/i }),
+		).toBeInTheDocument();
+	});
+
+	it("renders the policy note", () => {
+		render(<SpendingLimitsCard />);
+		expect(
+			screen.getByText(/spending limits are enforced in real-time/i),
+		).toBeInTheDocument();
+	});
+
+	it("updates daily limit and recalculates usage percentage", async () => {
+		const user = userEvent.setup();
+		render(<SpendingLimitsCard />);
+
+		const dailyInput = screen.getByRole("spinbutton", { name: /daily spending limit/i });
 		await user.clear(dailyInput);
 		await user.type(dailyInput, "1500");
 
@@ -102,91 +71,250 @@ describe("SpendingLimitsCard", () => {
 		expect(screen.getByText("50.0%")).toBeInTheDocument();
 	});
 
-	it("caps usage percentage at 100 when limit is less than used amount", async () => {
+	it("caps usage percentage at 100%", async () => {
 		const user = userEvent.setup();
 		render(<SpendingLimitsCard />);
 
-		const dailyInput = screen.getByRole("spinbutton", {
-			name: /daily spending limit/i,
-		});
+		const dailyInput = screen.getByRole("spinbutton", { name: /daily spending limit/i });
 		await user.clear(dailyInput);
 		await user.type(dailyInput, "100");
 
-		// 750 / 100 = 750%, capped at 100%
 		expect(screen.getByText("100.0%")).toBeInTheDocument();
 	});
 
-	it("shows 0% usage when daily limit is invalid (empty)", async () => {
-		const user = userEvent.setup();
+	it("renders helper text under each input", () => {
 		render(<SpendingLimitsCard />);
-
-		const dailyInput = screen.getByRole("spinbutton", {
-			name: /daily spending limit/i,
-		});
-		await user.clear(dailyInput);
-
-		// parseInt("") = NaN, fallback to 1 → 750/1 = 75000% capped at 100%
-		expect(screen.getByText("100.0%")).toBeInTheDocument();
+		expect(
+			screen.getByText(/maximum amount you can spend per day/i),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(/maximum cap for a single transaction/i),
+		).toBeInTheDocument();
 	});
 
-	it("shows 0% usage when daily limit is 0", async () => {
-		const user = userEvent.setup();
+	it("inputs are associated with labels (accessibility)", () => {
 		render(<SpendingLimitsCard />);
-
-		const dailyInput = screen.getByRole("spinbutton", {
-			name: /daily spending limit/i,
-		});
-		await user.clear(dailyInput);
-		await user.type(dailyInput, "0");
-
-		// parseInt("0") = 0, fallback to 1 → 750/1 = 75000% capped at 100%
-		expect(screen.getByText("100.0%")).toBeInTheDocument();
-	});
-
-	it("updates per-transaction limit independently", async () => {
-		const user = userEvent.setup();
-		render(<SpendingLimitsCard />);
-
-		const txInput = screen.getByRole("spinbutton", {
-			name: /per-transaction limit/i,
-		});
-		await user.clear(txInput);
-		await user.type(txInput, "2500");
-
-		expect(txInput).toHaveValue(2500);
-
-		// Daily limit and usage should remain unchanged
-		const dailyInput = screen.getByRole("spinbutton", {
-			name: /daily spending limit/i,
-		});
-		expect(dailyInput).toHaveValue(5000);
-		expect(screen.getByText("15.0%")).toBeInTheDocument();
-	});
-
-	it("has proper accessibility: inputs are associated with labels", async () => {
-		render(<SpendingLimitsCard />);
-		await waitFor(() => {
-			expect(screen.getByLabelText(/daily spending limit/i)).toBeInTheDocument();
-		});
-		await waitFor(() => {
-			expect(screen.getByLabelText(/per-transaction limit/i)).toBeInTheDocument();
-		});
-	});
-
-	it("renders helper text under each input", async () => {
-		render(<SpendingLimitsCard />);
-		await waitFor(() => {
-			expect(
-				screen.getByText(/maximum amount you can spend per day/i),
-			).toBeInTheDocument();
-		});
-		await waitFor(() => {
-			expect(
-				screen.getByText(/maximum cap for a single transaction/i),
-			).toBeInTheDocument();
-		});
+		expect(screen.getByLabelText(/daily spending limit/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/per-transaction limit/i)).toBeInTheDocument();
 	});
 });
+
+// ---------------------------------------------------------------------------
+// #266 – Empty state
+// ---------------------------------------------------------------------------
+
+describe("SpendingLimitsEmptyState", () => {
+	it("renders the empty state heading and description", () => {
+		render(<SpendingLimitsEmptyState onConfigure={vi.fn()} />);
+		expect(screen.getByText(/no spending limits set/i)).toBeInTheDocument();
+		expect(
+			screen.getByText(/configure daily and per-transaction limits/i),
+		).toBeInTheDocument();
+	});
+
+	it("renders the Configure Limits button", () => {
+		render(<SpendingLimitsEmptyState onConfigure={vi.fn()} />);
+		expect(
+			screen.getByRole("button", { name: /configure limits/i }),
+		).toBeInTheDocument();
+	});
+
+	it("calls onConfigure when the button is clicked", async () => {
+		const user = userEvent.setup();
+		const onConfigure = vi.fn();
+		render(<SpendingLimitsEmptyState onConfigure={onConfigure} />);
+		await user.click(screen.getByRole("button", { name: /configure limits/i }));
+		expect(onConfigure).toHaveBeenCalledTimes(1);
+	});
+
+	it("has accessible role and label", () => {
+		render(<SpendingLimitsEmptyState onConfigure={vi.fn()} />);
+		expect(
+			screen.getByRole("status", { name: /no spending limits configured/i }),
+		).toBeInTheDocument();
+	});
+});
+
+describe("SpendingLimitsCard empty prop", () => {
+	it("shows empty state when empty=true", () => {
+		render(<SpendingLimitsCard empty />);
+		expect(screen.getByText(/no spending limits set/i)).toBeInTheDocument();
+		// The main card heading (h2) should not be present — only the empty state h3 is
+		expect(screen.queryByRole("heading", { name: /^spending limits$/i })).not.toBeInTheDocument();
+	});
+
+	it("transitions from empty to card when Configure Limits is clicked", async () => {
+		const user = userEvent.setup();
+		render(<SpendingLimitsCard empty />);
+		await user.click(screen.getByRole("button", { name: /configure limits/i }));
+		expect(
+			screen.getByRole("heading", { name: /spending limits/i }),
+		).toBeInTheDocument();
+	});
+
+	it("shows card content when empty=false (default)", () => {
+		render(<SpendingLimitsCard />);
+		expect(
+			screen.getByRole("heading", { name: /spending limits/i }),
+		).toBeInTheDocument();
+		expect(screen.queryByText(/no spending limits set/i)).not.toBeInTheDocument();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// #267 – Error state
+// ---------------------------------------------------------------------------
+
+describe("SpendingLimitsErrorState", () => {
+	it("renders the default error heading and message", () => {
+		render(<SpendingLimitsErrorState onRetry={vi.fn()} />);
+		expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
+		expect(
+			screen.getByText(/unable to load spending limits/i),
+		).toBeInTheDocument();
+	});
+
+	it("renders a custom error message", () => {
+		render(
+			<SpendingLimitsErrorState message="Network error" onRetry={vi.fn()} />,
+		);
+		expect(screen.getByText("Network error")).toBeInTheDocument();
+	});
+
+	it("renders the Try Again button", () => {
+		render(<SpendingLimitsErrorState onRetry={vi.fn()} />);
+		expect(
+			screen.getByRole("button", { name: /try again/i }),
+		).toBeInTheDocument();
+	});
+
+	it("calls onRetry when Try Again is clicked", async () => {
+		const user = userEvent.setup();
+		const onRetry = vi.fn();
+		render(<SpendingLimitsErrorState onRetry={onRetry} />);
+		await user.click(screen.getByRole("button", { name: /try again/i }));
+		expect(onRetry).toHaveBeenCalledTimes(1);
+	});
+
+	it("has accessible role=alert and label", () => {
+		render(<SpendingLimitsErrorState onRetry={vi.fn()} />);
+		expect(
+			screen.getByRole("alert", { name: /error loading spending limits/i }),
+		).toBeInTheDocument();
+	});
+});
+
+describe("SpendingLimitsCard fetchError prop", () => {
+	it("shows error state when fetchError is provided", () => {
+		render(<SpendingLimitsCard fetchError="Service unavailable" />);
+		expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
+		expect(screen.getByText("Service unavailable")).toBeInTheDocument();
+	});
+
+	it("does not show the card content when fetchError is set", () => {
+		render(<SpendingLimitsCard fetchError="oops" />);
+		expect(
+			screen.queryByRole("heading", { name: /spending limits/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("shows card content when fetchError is null", () => {
+		render(<SpendingLimitsCard fetchError={null} />);
+		expect(
+			screen.getByRole("heading", { name: /spending limits/i }),
+		).toBeInTheDocument();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// #268 – Loading skeleton
+// ---------------------------------------------------------------------------
+
+describe("SpendingLimitsCardSkeleton", () => {
+	it("renders animate-pulse skeleton elements", () => {
+		const { container } = render(<SpendingLimitsCardSkeleton />);
+		const skeletons = container.querySelectorAll(".animate-pulse");
+		expect(skeletons.length).toBeGreaterThan(0);
+	});
+
+	it("has accessible status role and label", () => {
+		render(<SpendingLimitsCardSkeleton />);
+		expect(
+			screen.getByRole("status", { name: /loading spending limits/i }),
+		).toBeInTheDocument();
+	});
+
+	it("is aria-busy=true", () => {
+		render(<SpendingLimitsCardSkeleton />);
+		const el = screen.getByRole("status", { name: /loading spending limits/i });
+		expect(el).toHaveAttribute("aria-busy", "true");
+	});
+});
+
+describe("SpendingLimitsCard loading prop", () => {
+	it("renders skeleton when loading=true", () => {
+		const { container } = render(<SpendingLimitsCard loading />);
+		const skeletons = container.querySelectorAll(".animate-pulse");
+		expect(skeletons.length).toBeGreaterThan(0);
+	});
+
+	it("does not render card content when loading=true", () => {
+		render(<SpendingLimitsCard loading />);
+		expect(
+			screen.queryByRole("heading", { name: /spending limits/i }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("spinbutton", { name: /daily spending limit/i }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: /save settings/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("renders card content when loading=false", () => {
+		render(<SpendingLimitsCard loading={false} />);
+		expect(
+			screen.getByRole("heading", { name: /spending limits/i }),
+		).toBeInTheDocument();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// #269 – Responsive layout
+// ---------------------------------------------------------------------------
+
+describe("SpendingLimitsCard responsive layout", () => {
+	it("inputs grid has responsive classes (md:grid-cols-2)", () => {
+		const { container } = render(<SpendingLimitsCard />);
+		const grid = container.querySelector(".grid.grid-cols-1.gap-6.md\\:grid-cols-2");
+		expect(grid).toBeInTheDocument();
+	});
+
+	it("footer has responsive flex classes (sm:flex-row)", () => {
+		const { container } = render(<SpendingLimitsCard />);
+		const footer = container.querySelector(
+			".flex.flex-col.items-stretch.gap-3.bg-zinc-50",
+		);
+		expect(footer).toBeInTheDocument();
+		expect(footer).toHaveClass("sm:flex-row");
+	});
+
+	it("skeleton inputs grid is also responsive (md:grid-cols-2)", () => {
+		const { container } = render(<SpendingLimitsCardSkeleton />);
+		const grid = container.querySelector(".grid.grid-cols-1.gap-6.md\\:grid-cols-2");
+		expect(grid).toBeInTheDocument();
+	});
+
+	it("Save Settings button has full-width on mobile, auto on sm+", () => {
+		const { container } = render(<SpendingLimitsCard />);
+		const btn = container.querySelector(".w-full.rounded-full.px-6.sm\\:ml-auto.sm\\:w-auto");
+		expect(btn).toBeInTheDocument();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Keyboard navigation
+// ---------------------------------------------------------------------------
 
 describe("SpendingLimitsCard keyboard navigation", () => {
 	beforeEach(() => {
@@ -200,26 +328,22 @@ describe("SpendingLimitsCard keyboard navigation", () => {
 		vi.unstubAllGlobals();
 	});
 
-	it("pressing Enter in the daily limit input triggers save", async () => {
+	it("pressing Enter in daily limit input triggers save", async () => {
 		const user = userEvent.setup();
 		render(<SpendingLimitsCard />);
 
-		const dailyInput = screen.getByRole("spinbutton", {
-			name: /daily spending limit/i,
-		});
+		const dailyInput = screen.getByRole("spinbutton", { name: /daily spending limit/i });
 		await user.click(dailyInput);
 		await user.keyboard("{Enter}");
 
 		expect(localStorage.setItem).toHaveBeenCalled();
 	});
 
-	it("pressing Enter in the tx limit input triggers save", async () => {
+	it("pressing Enter in tx limit input triggers save", async () => {
 		const user = userEvent.setup();
 		render(<SpendingLimitsCard />);
 
-		const txInput = screen.getByRole("spinbutton", {
-			name: /per-transaction limit/i,
-		});
+		const txInput = screen.getByRole("spinbutton", { name: /per-transaction limit/i });
 		await user.click(txInput);
 		await user.keyboard("{Enter}");
 
@@ -230,75 +354,18 @@ describe("SpendingLimitsCard keyboard navigation", () => {
 		const user = userEvent.setup();
 		render(<SpendingLimitsCard />);
 
-		const dailyInput = screen.getByRole("spinbutton", {
-			name: /daily spending limit/i,
-		});
+		const dailyInput = screen.getByRole("spinbutton", { name: /daily spending limit/i });
 		await user.click(dailyInput);
 		expect(dailyInput).toHaveFocus();
 
 		await user.keyboard("{Escape}");
 		expect(dailyInput).not.toHaveFocus();
 	});
-
-	it("Save Settings button is focusable via keyboard", async () => {
-		const user = userEvent.setup();
-		render(<SpendingLimitsCard />);
-
-		const saveBtn = screen.getByRole("button", { name: /save settings/i });
-		saveBtn.focus();
-		expect(saveBtn).toHaveFocus();
-
-		await user.keyboard("{Enter}");
-		expect(localStorage.setItem).toHaveBeenCalled();
-	});
 });
 
-describe("SpendingLimitsCard loading state", () => {
-	it("renders skeleton placeholders when loading is true", () => {
-		const { container } = render(<SpendingLimitsCard loading />);
-
-		const skeletons = container.querySelectorAll(".animate-pulse");
-		expect(skeletons.length).toBeGreaterThan(0);
-	});
-
-	it("does not render real content when loading", () => {
-		render(<SpendingLimitsCard loading />);
-
-		expect(
-			screen.queryByRole("heading", { name: /spending limits/i }),
-		).not.toBeInTheDocument();
-		expect(
-			screen.queryByRole("spinbutton", { name: /daily spending limit/i }),
-		).not.toBeInTheDocument();
-		expect(
-			screen.queryByRole("button", { name: /save settings/i }),
-		).not.toBeInTheDocument();
-		expect(screen.queryByText("Active")).not.toBeInTheDocument();
-	});
-
-	it("renders real content when loading is false", async () => {
-		render(<SpendingLimitsCard loading={false} />);
-		await waitFor(() => {
-			expect(
-				screen.getByRole("heading", { name: /spending limits/i }),
-			).toBeInTheDocument();
-		});
-		await waitFor(() => {
-			expect(
-				screen.getByRole("button", { name: /save settings/i }),
-			).toBeInTheDocument();
-		});
-	});
-
-	it("renders real content by default (loading not set)", async () => {
-		render(<SpendingLimitsCard />);
-		await waitFor(() => {
-			expect(
-				screen.getByRole("heading", { name: /spending limits/i }),
-			).toBeInTheDocument();
-		});
-	});
-});
+// ---------------------------------------------------------------------------
+// Toast feedback
+// ---------------------------------------------------------------------------
 
 describe("SpendingLimitsCard toast feedback", () => {
 	beforeEach(() => {
@@ -335,7 +402,8 @@ describe("SpendingLimitsCard toast feedback", () => {
 
 		expect(screen.getByRole("status")).toBeInTheDocument();
 		expect(screen.getByText("Error")).toBeInTheDocument();
-		expect(screen.getByText(/failed to save/i)).toBeInTheDocument();
+		// "Failed to save" appears in both the inline error and the toast
+		expect(screen.getAllByText(/failed to save/i).length).toBeGreaterThan(0);
 	});
 
 	it("toast is not visible before saving", () => {

--- a/src/components/dashboard/SpendingLimitsCard.tsx
+++ b/src/components/dashboard/SpendingLimitsCard.tsx
@@ -13,7 +13,6 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { Toast } from "@/components/ui/toast";
-import type { SpendingLimitsResponse } from "@/app/api/spending-limits/route";
 
 // Allow pressing Enter in an input to trigger save, Escape to blur.
 function useInputKeyNav(onSave: () => void) {
@@ -31,6 +30,8 @@ const STORAGE_KEY = "spending-limits";
 const MIN_LIMIT = 1;
 const MAX_LIMIT = 1000000;
 const COPY_RESET_MS = 2000;
+/** Mock today's usage — in production this would come from the API. */
+const TODAY_USAGE = 750;
 
 function parseLimit(value: string) {
 	const number = Number(value);
@@ -52,24 +53,201 @@ function validateLimit(value: string): string | null {
 	return null;
 }
 
+// ---------------------------------------------------------------------------
+// CopyButton
+// ---------------------------------------------------------------------------
+
+interface CopyButtonProps {
+	value: string;
+	label: string;
+}
+
+function CopyButton({ value, label }: CopyButtonProps) {
+	const [copied, setCopied] = useState(false);
+	const timeoutRef = useRef<number | null>(null);
+
+	const handleCopy = useCallback(async () => {
+		try {
+			await navigator.clipboard.writeText(value);
+			setCopied(true);
+			if (timeoutRef.current) window.clearTimeout(timeoutRef.current);
+			timeoutRef.current = window.setTimeout(() => setCopied(false), COPY_RESET_MS);
+		} catch {
+			// clipboard not available
+		}
+	}, [value]);
+
+	return (
+		<button
+			type="button"
+			aria-label={`Copy ${label}`}
+			onClick={handleCopy}
+			className="inline-flex items-center gap-1 rounded p-1 text-zinc-400 transition-colors hover:text-zinc-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:hover:text-zinc-200"
+		>
+			{copied ? (
+				<Check className="size-3.5 text-green-500" />
+			) : (
+				<Clipboard className="size-3.5" />
+			)}
+		</button>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+interface SpendingLimitsEmptyStateProps {
+	onConfigure: () => void;
+}
+
+export function SpendingLimitsEmptyState({ onConfigure }: SpendingLimitsEmptyStateProps) {
+	return (
+		<div
+			role="status"
+			aria-label="No spending limits configured"
+			className="flex min-h-[320px] w-full flex-col items-center justify-center rounded-xl border border-dashed border-zinc-200 bg-zinc-50/50 p-8 text-center dark:border-zinc-800 dark:bg-zinc-900/50"
+		>
+			<div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
+				<DollarSign className="size-8 text-zinc-400 dark:text-zinc-500" aria-hidden="true" />
+			</div>
+			<h3 className="mb-2 text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+				No spending limits set
+			</h3>
+			<p className="mb-6 max-w-xs text-sm text-zinc-500 dark:text-zinc-400">
+				Configure daily and per-transaction limits to control your API expenditure and protect against overspend.
+			</p>
+			<Button onClick={onConfigure} className="rounded-full px-6">
+				Configure Limits
+			</Button>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Error state
+// ---------------------------------------------------------------------------
+
+interface SpendingLimitsErrorStateProps {
+	message?: string;
+	onRetry: () => void;
+}
+
+export function SpendingLimitsErrorState({
+	message = "Unable to load spending limits. Please try again.",
+	onRetry,
+}: SpendingLimitsErrorStateProps) {
+	return (
+		<div
+			role="alert"
+			aria-label="Error loading spending limits"
+			className="flex min-h-[320px] w-full flex-col items-center justify-center rounded-xl border border-red-100 bg-red-50/50 p-8 text-center dark:border-red-900/30 dark:bg-red-900/10"
+		>
+			<div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
+				<AlertCircle className="size-8 text-red-600 dark:text-red-400" aria-hidden="true" />
+			</div>
+			<h3 className="mb-2 text-lg font-semibold text-red-900 dark:text-red-100">
+				Failed to load
+			</h3>
+			<p className="mb-6 max-w-xs text-sm text-red-700 dark:text-red-400">{message}</p>
+			<button
+				type="button"
+				onClick={onRetry}
+				className="inline-flex h-10 items-center justify-center rounded-lg bg-red-600 px-6 text-sm font-medium text-white transition-colors hover:bg-red-700 dark:bg-red-500 dark:hover:bg-red-600"
+			>
+				Try Again
+			</button>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+export function SpendingLimitsCardSkeleton() {
+	return (
+		<div
+			role="status"
+			aria-label="Loading spending limits"
+			aria-busy="true"
+			aria-live="polite"
+			className="overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-950"
+		>
+			<div className="flex items-center justify-between border-b border-zinc-200 p-6 dark:border-zinc-800">
+				<div className="flex items-center gap-3">
+					<Skeleton className="h-9 w-9 rounded-lg" />
+					<div className="space-y-1.5">
+						<Skeleton className="h-5 w-36" />
+						<Skeleton className="h-4 w-56" />
+					</div>
+				</div>
+				<Skeleton className="h-5 w-14 rounded-full" />
+			</div>
+			<div className="space-y-8 p-6">
+				<div className="space-y-3">
+					<div className="flex items-end justify-between">
+						<div className="space-y-1">
+							<Skeleton className="h-4 w-20" />
+							<Skeleton className="h-7 w-28" />
+						</div>
+						<Skeleton className="h-4 w-10" />
+					</div>
+					<Skeleton className="h-2 w-full rounded-full" />
+				</div>
+				{/* Responsive grid: stacked on mobile, 2-col on md+ */}
+				<div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+					<div className="space-y-2">
+						<Skeleton className="h-4 w-36" />
+						<Skeleton className="h-9 w-full rounded-lg" />
+						<Skeleton className="h-3 w-48" />
+					</div>
+					<div className="space-y-2">
+						<Skeleton className="h-4 w-36" />
+						<Skeleton className="h-9 w-full rounded-lg" />
+						<Skeleton className="h-3 w-44" />
+					</div>
+				</div>
+				<Skeleton className="h-16 w-full rounded-lg" />
+			</div>
+			<div className="flex justify-end bg-zinc-50 px-6 py-4 dark:bg-zinc-900/50">
+				<Skeleton className="h-9 w-32 rounded-full" />
+			</div>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Main card
+// ---------------------------------------------------------------------------
+
 interface SpendingLimitsCardProps {
+	/** Show loading skeleton while data is being fetched. */
 	loading?: boolean;
+	/** Show error state if data fetch failed. */
+	fetchError?: string | null;
+	/** Show empty state if no limits have been configured yet. */
+	empty?: boolean;
 }
 
 export function SpendingLimitsCard({
 	loading = false,
+	fetchError = null,
+	empty = false,
 }: SpendingLimitsCardProps) {
 	const [dailyLimit, setDailyLimit] = useState("5000");
 	const [transactionLimit, setTransactionLimit] = useState("1000");
 	const [dailyError, setDailyError] = useState<string | null>(null);
 	const [txError, setTxError] = useState<string | null>(null);
+	const [saveInProgress, setSaveInProgress] = useState(false);
+	const [error, setError] = useState<string | null>(null);
 	const [toastOpen, setToastOpen] = useState(false);
 	const [toastVariant, setToastVariant] = useState<"success" | "error">("success");
 	const [toastMessage, setToastMessage] = useState("Spending limits saved.");
+	const [isEmpty, setIsEmpty] = useState(empty);
 
 	const toastTimeoutRef = useRef<number | null>(null);
 
-	// Fetch limits from API on mount
 	useEffect(() => {
 		try {
 			const stored = window.localStorage.getItem(STORAGE_KEY);
@@ -81,17 +259,38 @@ export function SpendingLimitsCard({
 			if (typeof parsed?.transactionLimit === "number" && isFinite(parsed.transactionLimit)) {
 				setTransactionLimit(String(parsed.transactionLimit));
 			}
+		} catch {
+			// ignore parse errors
 		}
 		return () => {
 			if (toastTimeoutRef.current) window.clearTimeout(toastTimeoutRef.current);
 		};
 	}, []);
 
-	const usedAmount = todayUsage;
+	const usedAmount = TODAY_USAGE;
 	const totalLimit = Number.parseInt(dailyLimit) || 1;
 	const usagePercentage = Math.min((usedAmount / totalLimit) * 100, 100);
 
+	// --- State rendering guards ---
+
 	if (loading) return <SpendingLimitsCardSkeleton />;
+
+	if (fetchError) {
+		return (
+			<SpendingLimitsErrorState
+				message={fetchError}
+				onRetry={() => window.location.reload()}
+			/>
+		);
+	}
+
+	if (isEmpty) {
+		return (
+			<SpendingLimitsEmptyState onConfigure={() => setIsEmpty(false)} />
+		);
+	}
+
+	// --- Handlers ---
 
 	const showToast = (variant: "success" | "error", message: string) => {
 		setToastVariant(variant);
@@ -102,6 +301,14 @@ export function SpendingLimitsCard({
 	};
 
 	const handleSave = () => {
+		const dErr = validateLimit(dailyLimit);
+		const tErr = validateLimit(transactionLimit);
+		setDailyError(dErr);
+		setTxError(tErr);
+		if (dErr || tErr) return;
+
+		setSaveInProgress(true);
+		setError(null);
 		try {
 			window.localStorage.setItem(
 				STORAGE_KEY,
@@ -112,7 +319,10 @@ export function SpendingLimitsCard({
 			);
 			showToast("success", "Spending limits saved.");
 		} catch {
+			setError("Failed to save. Please try again.");
 			showToast("error", "Failed to save. Please try again.");
+		} finally {
+			setSaveInProgress(false);
 		}
 	};
 
@@ -121,10 +331,11 @@ export function SpendingLimitsCard({
 	return (
 		<>
 			<div className="overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-950">
+				{/* Header */}
 				<div className="flex items-center justify-between border-b border-zinc-200 p-6 dark:border-zinc-800">
 					<div className="flex items-center gap-3">
 						<div className="rounded-lg bg-zinc-100 p-2 dark:bg-zinc-900">
-							<TrendingUp className="size-5 text-zinc-600 dark:text-zinc-400" />
+							<TrendingUp className="size-5 text-zinc-600 dark:text-zinc-400" aria-hidden="true" />
 						</div>
 						<div>
 							<h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">
@@ -143,7 +354,9 @@ export function SpendingLimitsCard({
 					</Badge>
 				</div>
 
+				{/* Body */}
 				<div className="space-y-8 p-6">
+					{/* Usage bar */}
 					<div className="space-y-3">
 						<div className="flex items-end justify-between">
 							<div>
@@ -169,20 +382,22 @@ export function SpendingLimitsCard({
 						</div>
 					</div>
 
+					{/* Inputs — responsive: stacked on mobile, 2-col on md+ */}
 					<div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+						{/* Daily limit */}
 						<div className="space-y-2">
 							<div className="flex items-center justify-between">
 								<label
 									htmlFor="daily-limit"
 									className="flex items-center gap-2 text-sm font-medium text-zinc-700 dark:text-zinc-300"
 								>
-									<DollarSign className="size-4" />
+									<DollarSign className="size-4" aria-hidden="true" />
 									Daily Spending Limit
 								</label>
 								<CopyButton value={dailyLimit} label="daily limit" />
 							</div>
 							<div className="relative">
-								<span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-400">
+								<span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-400" aria-hidden="true">
 									$
 								</span>
 								<input
@@ -193,6 +408,7 @@ export function SpendingLimitsCard({
 									step={1}
 									value={dailyLimit}
 									onChange={(e) => { setDailyLimit(e.target.value); setDailyError(null); }}
+									onKeyDown={handleInputKeyDown}
 									aria-invalid={dailyError !== null}
 									aria-describedby={dailyError ? "daily-limit-error" : undefined}
 									className={`w-full rounded-lg border bg-zinc-50 py-2 pl-7 pr-3 text-sm transition-all focus:outline-none focus:ring-2 dark:bg-zinc-900 ${
@@ -212,19 +428,20 @@ export function SpendingLimitsCard({
 							)}
 						</div>
 
+						{/* Per-transaction limit */}
 						<div className="space-y-2">
 							<div className="flex items-center justify-between">
 								<label
 									htmlFor="tx-limit"
 									className="flex items-center gap-2 text-sm font-medium text-zinc-700 dark:text-zinc-300"
 								>
-									<Wallet className="size-4" />
+									<Wallet className="size-4" aria-hidden="true" />
 									Per-Transaction Limit
 								</label>
 								<CopyButton value={transactionLimit} label="transaction limit" />
 							</div>
 							<div className="relative">
-								<span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-400">
+								<span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-400" aria-hidden="true">
 									$
 								</span>
 								<input
@@ -235,6 +452,7 @@ export function SpendingLimitsCard({
 									step={1}
 									value={transactionLimit}
 									onChange={(e) => { setTransactionLimit(e.target.value); setTxError(null); }}
+									onKeyDown={handleInputKeyDown}
 									aria-invalid={txError !== null}
 									aria-describedby={txError ? "tx-limit-error" : undefined}
 									className={`w-full rounded-lg border bg-zinc-50 py-2 pl-7 pr-3 text-sm transition-all focus:outline-none focus:ring-2 dark:bg-zinc-900 ${
@@ -255,8 +473,9 @@ export function SpendingLimitsCard({
 						</div>
 					</div>
 
+					{/* Policy note */}
 					<div className="flex gap-3 rounded-lg border border-blue-100 bg-blue-50/50 p-4 dark:border-blue-500/10 dark:bg-blue-500/5">
-						<AlertCircle className="size-5 shrink-0 text-blue-600 dark:text-blue-400" />
+						<AlertCircle className="size-5 shrink-0 text-blue-600 dark:text-blue-400" aria-hidden="true" />
 						<p className="text-xs leading-relaxed text-blue-800 dark:text-blue-300">
 							Spending limits are enforced in real-time. If a transaction
 							exceeds your per-transaction limit or if your daily limit is
@@ -266,14 +485,15 @@ export function SpendingLimitsCard({
 					</div>
 				</div>
 
-				<div className="flex flex-col sm:flex-row items-end justify-between gap-3 bg-zinc-50 px-6 py-4 dark:bg-zinc-900/50">
+				{/* Footer — responsive: column on mobile, row on sm+ */}
+				<div className="flex flex-col items-stretch gap-3 bg-zinc-50 px-6 py-4 sm:flex-row sm:items-center sm:justify-between dark:bg-zinc-900/50">
 					{error && (
-						<p className="text-xs text-red-600 leading-relaxed">
+						<p className="text-xs text-red-600 leading-relaxed dark:text-red-400">
 							{error}
 						</p>
 					)}
 					<Button
-						className="rounded-full px-6 shrink-0"
+						className="w-full rounded-full px-6 sm:ml-auto sm:w-auto"
 						onClick={handleSave}
 						disabled={saveInProgress}
 					>
@@ -283,50 +503,5 @@ export function SpendingLimitsCard({
 			</div>
 			<Toast open={toastOpen} message={toastMessage} variant={toastVariant} />
 		</>
-	);
-}
-
-function SpendingLimitsCardSkeleton() {
-	return (
-		<div className="overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-950">
-			<div className="flex items-center justify-between border-b border-zinc-200 p-6 dark:border-zinc-800">
-				<div className="flex items-center gap-3">
-					<Skeleton className="h-9 w-9 rounded-lg" />
-					<div className="space-y-1.5">
-						<Skeleton className="h-5 w-36" />
-						<Skeleton className="h-4 w-56" />
-					</div>
-				</div>
-				<Skeleton className="h-5 w-14 rounded-full" />
-			</div>
-			<div className="space-y-8 p-6">
-				<div className="space-y-3">
-					<div className="flex items-end justify-between">
-						<div className="space-y-1">
-							<Skeleton className="h-4 w-20" />
-							<Skeleton className="h-7 w-28" />
-						</div>
-						<Skeleton className="h-4 w-10" />
-					</div>
-					<Skeleton className="h-2 w-full rounded-full" />
-				</div>
-				<div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-					<div className="space-y-2">
-						<Skeleton className="h-4 w-36" />
-						<Skeleton className="h-9 w-full rounded-lg" />
-						<Skeleton className="h-3 w-48" />
-					</div>
-					<div className="space-y-2">
-						<Skeleton className="h-4 w-36" />
-						<Skeleton className="h-9 w-full rounded-lg" />
-						<Skeleton className="h-3 w-44" />
-					</div>
-				</div>
-				<Skeleton className="h-16 w-full rounded-lg" />
-			</div>
-			<div className="flex justify-end bg-zinc-50 px-6 py-4 dark:bg-zinc-900/50">
-				<Skeleton className="h-9 w-32 rounded-full" />
-			</div>
-		</div>
 	);
 }


### PR DESCRIPTION
Description

Add an explicit error state UI to the Spending Limits interface so users receive clear feedback whenever spending limit data cannot be loaded, updated, or validated. The implementation should gracefully handle scenarios such as network failures, stale or disconnected sessions, and invalid responses while remaining consistent with the existing design system and state management patterns.

The change should include the necessary runtime state handling, user-facing error messaging, and recovery actions (such as retry where appropriate). Add or update unit, integration, and UI tests to verify the new behavior and ensure no regressions in related spending limit workflows. If any public API or user-facing behavior changes, update the relevant documentation accordingly.
closes #267 