### PR TITLE
feat(recovery): add keyboard navigation to timeline and FAQ (#315)

### DIFF
--- a/src/components/recovery/RecoveryFAQ.tsx
+++ b/src/components/recovery/RecoveryFAQ.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { RecoveryDocsLink } from "./RecoveryDocsLink";
 
@@ -80,18 +80,37 @@ interface FAQItemProps {
 	item: FAQItem;
 	isOpen: boolean;
 	onToggle: () => void;
+	focused?: boolean;
+	tabIndex?: number;
+	onKeyDown?: (e: React.KeyboardEvent) => void;
+	buttonRef?: React.Ref<HTMLButtonElement>;
 }
 
-function FAQRow({ item, isOpen, onToggle }: FAQItemProps) {
+function FAQRow({
+	item,
+	isOpen,
+	onToggle,
+	focused = false,
+	tabIndex = 0,
+	onKeyDown,
+	buttonRef,
+}: FAQItemProps) {
 	return (
 		<div className="border-b border-zinc-200 dark:border-zinc-800 last:border-0">
 			<button
+				ref={buttonRef}
 				type="button"
 				aria-expanded={isOpen}
 				aria-controls={`faq-answer-${item.id}`}
 				id={`faq-question-${item.id}`}
 				onClick={onToggle}
-				className="flex w-full items-center justify-between gap-4 py-4 text-left text-sm font-medium text-zinc-900 dark:text-zinc-50 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 rounded-sm"
+				onKeyDown={onKeyDown}
+				tabIndex={tabIndex}
+				className={cn(
+					"flex w-full items-center justify-between gap-4 py-4 text-left text-sm font-medium text-zinc-900 dark:text-zinc-50 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 rounded-sm",
+					focused &&
+						"ring-2 ring-blue-500 ring-offset-2 dark:ring-blue-400 dark:ring-offset-zinc-900",
+				)}
 			>
 				<span>{item.question}</span>
 				<svg
@@ -137,10 +156,53 @@ export function RecoveryFAQ({
 	className,
 }: RecoveryFAQProps) {
 	const [openId, setOpenId] = useState<string | null>(null);
+	const [focusedIndex, setFocusedIndex] = useState<number>(-1);
+	const faqRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
 	const toggle = (id: string) => {
 		setOpenId((prev) => (prev === id ? null : id));
 	};
+
+	const handleKeyDown = useCallback(
+		(event: React.KeyboardEvent, index: number) => {
+			switch (event.key) {
+				case "ArrowDown":
+					event.preventDefault();
+					if (index < items.length - 1) {
+						setFocusedIndex(index + 1);
+						faqRefs.current[index + 1]?.focus();
+					}
+					break;
+				case "ArrowUp":
+					event.preventDefault();
+					if (index > 0) {
+						setFocusedIndex(index - 1);
+						faqRefs.current[index - 1]?.focus();
+					}
+					break;
+				case "Home":
+					event.preventDefault();
+					setFocusedIndex(0);
+					faqRefs.current[0]?.focus();
+					break;
+				case "End":
+					event.preventDefault();
+					const lastIndex = items.length - 1;
+					setFocusedIndex(lastIndex);
+					faqRefs.current[lastIndex]?.focus();
+					break;
+			}
+		},
+		[items.length],
+	);
+
+	const handleFocus = useCallback((index: number) => {
+		setFocusedIndex(index);
+	}, []);
+
+	const handleBlur = useCallback(() => {
+		setFocusedIndex(-1);
+	}, []);
 
 	return (
 		<section
@@ -163,12 +225,16 @@ export function RecoveryFAQ({
 				</p>
 			) : (
 				<div role="list" className="mb-4">
-					{items.map((item) => (
+					{items.map((item, index) => (
 						<div key={item.id} role="listitem">
 							<FAQRow
 								item={item}
 								isOpen={openId === item.id}
 								onToggle={() => toggle(item.id)}
+								focused={focusedIndex === index}
+								tabIndex={focusedIndex === index ? 0 : -1}
+								onKeyDown={(e) => handleKeyDown(e, index)}
+								buttonRef={(el) => { faqRefs.current[index] = el; }}
 							/>
 						</div>
 					))}

--- a/src/components/recovery/RecoveryTimelineEvent.tsx
+++ b/src/components/recovery/RecoveryTimelineEvent.tsx
@@ -141,6 +141,13 @@ export function RecoveryTimelineEvent({
 	isFirst = false,
 	onClick,
 	className,
+	focused = false,
+	tabIndex = -1,
+	onKeyDown,
+	eventRef,
+	testId,
+	onFocus,
+	onBlur,
 }: RecoveryTimelineEventProps) {
 	const statusColor = statusColors[event.status] || statusColors.pending;
 	const dotColor = dotColors[event.status] || dotColors.pending;
@@ -156,14 +163,22 @@ export function RecoveryTimelineEvent({
 			<div className="flex flex-col items-center">
 				{/* Dot */}
 				<button
+					ref={eventRef}
 					onClick={onClick}
+					onKeyDown={onKeyDown}
+					onFocus={onFocus}
+					onBlur={onBlur}
+					tabIndex={tabIndex}
 					className={cn(
-						"p-2 rounded-full transition-all",
+						"p-2 rounded-full transition-all focus-visible:outline-none",
 						statusColor,
 						onClick && "cursor-pointer hover:scale-110",
+						focused &&
+							"ring-2 ring-blue-500 ring-offset-2 dark:ring-blue-400 dark:ring-offset-zinc-900",
 					)}
 					aria-pressed={false}
 					title={event.title}
+					data-testid={testId}
 				>
 					{icon}
 				</button>

--- a/src/components/recovery/RecoveryTimelineList.tsx
+++ b/src/components/recovery/RecoveryTimelineList.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCallback, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import type { RecoveryTimelineListProps } from "@/types/recovery";
 import { RecoveryTimelineEvent } from "./RecoveryTimelineEvent";
@@ -32,6 +33,55 @@ export function RecoveryTimelineList({
 	onEventClick,
 	emptyMessage = "No recovery events to display",
 }: RecoveryTimelineListProps) {
+	const [focusedIndex, setFocusedIndex] = useState<number>(-1);
+	const eventRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+	const handleKeyDown = useCallback(
+		(event: React.KeyboardEvent, index: number) => {
+			switch (event.key) {
+				case "ArrowDown":
+					event.preventDefault();
+					if (index < events.length - 1) {
+						setFocusedIndex(index + 1);
+						eventRefs.current[index + 1]?.focus();
+					}
+					break;
+				case "ArrowUp":
+					event.preventDefault();
+					if (index > 0) {
+						setFocusedIndex(index - 1);
+						eventRefs.current[index - 1]?.focus();
+					}
+					break;
+				case "Enter":
+				case " ":
+					event.preventDefault();
+					onEventClick?.(events[index]);
+					break;
+				case "Home":
+					event.preventDefault();
+					setFocusedIndex(0);
+					eventRefs.current[0]?.focus();
+					break;
+				case "End":
+					event.preventDefault();
+					const lastIndex = events.length - 1;
+					setFocusedIndex(lastIndex);
+					eventRefs.current[lastIndex]?.focus();
+					break;
+			}
+		},
+		[events, onEventClick],
+	);
+
+	const handleFocus = useCallback((index: number) => {
+		setFocusedIndex(index);
+	}, []);
+
+	const handleBlur = useCallback(() => {
+		setFocusedIndex(-1);
+	}, []);
+
 	// Handle empty state
 	if (!events || events.length === 0) {
 		return (
@@ -121,6 +171,13 @@ export function RecoveryTimelineList({
 						isFirst={index === 0}
 						isLast={index === events.length - 1}
 						onClick={() => onEventClick?.(event)}
+						focused={focusedIndex === index}
+						tabIndex={focusedIndex === index ? 0 : -1}
+						onKeyDown={(e) => handleKeyDown(e, index)}
+						eventRef={(el) => { eventRefs.current[index] = el; }}
+						onFocus={() => handleFocus(index)}
+						onBlur={handleBlur}
+						testId={`recovery-event-${index}`}
 						className={cn(
 							"transition-all",
 							onEventClick &&

--- a/src/components/recovery/__tests__/RecoveryFAQ.test.tsx
+++ b/src/components/recovery/__tests__/RecoveryFAQ.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import type { FAQItem } from "../RecoveryFAQ";
@@ -14,7 +14,7 @@ describe("RecoveryFAQ", () => {
 	it("renders FAQ heading and items", () => {
 		render(<RecoveryFAQ />);
 		expect(
-			screen.getByRole("heading", { name: /frequently asked questions/i })
+			screen.getByRole("heading", { name: /frequently asked questions/i }),
 		).toBeInTheDocument();
 		expect(screen.getAllByRole("listitem").length).toBeGreaterThan(0);
 	});
@@ -31,8 +31,121 @@ describe("RecoveryFAQ", () => {
 	it("expands and collapses FAQ items", () => {
 		render(<RecoveryFAQ />);
 		const firstQuestion = screen.getAllByRole("button")[0];
-		
+
 		fireEvent.click(firstQuestion);
 		expect(firstQuestion).toHaveAttribute("aria-expanded", "true");
+	});
+
+	it("renders custom items", () => {
+		render(<RecoveryFAQ items={SAMPLE} />);
+		expect(screen.getByText("First question?")).toBeInTheDocument();
+		expect(screen.getByText("Second question?")).toBeInTheDocument();
+		expect(screen.getByText("Third question?")).toBeInTheDocument();
+	});
+
+	it("handles empty items array", () => {
+		render(<RecoveryFAQ items={[]} />);
+		expect(
+			screen.getByText("No FAQ items available."),
+		).toBeInTheDocument();
+	});
+
+	describe("Keyboard navigation", () => {
+		it("should navigate down with ArrowDown", async () => {
+			const user = userEvent.setup();
+			render(<RecoveryFAQ items={SAMPLE} />);
+
+			const buttons = screen.getAllByRole("button");
+			buttons[0].focus();
+			await user.keyboard("{ArrowDown}");
+			expect(buttons[1]).toHaveFocus();
+		});
+
+		it("should navigate up with ArrowUp", async () => {
+			const user = userEvent.setup();
+			render(<RecoveryFAQ items={SAMPLE} />);
+
+			const buttons = screen.getAllByRole("button");
+			buttons[1].focus();
+			await user.keyboard("{ArrowUp}");
+			expect(buttons[0]).toHaveFocus();
+		});
+
+		it("should navigate to first item with Home", async () => {
+			const user = userEvent.setup();
+			render(<RecoveryFAQ items={SAMPLE} />);
+
+			const buttons = screen.getAllByRole("button");
+			const lastIndex = buttons.length - 1;
+			buttons[lastIndex].focus();
+			await user.keyboard("{Home}");
+			expect(buttons[0]).toHaveFocus();
+		});
+
+		it("should navigate to last item with End", async () => {
+			const user = userEvent.setup();
+			render(<RecoveryFAQ items={SAMPLE} />);
+
+			const buttons = screen.getAllByRole("button");
+			const lastIndex = buttons.length - 1;
+			buttons[0].focus();
+			await user.keyboard("{End}");
+			expect(buttons[lastIndex]).toHaveFocus();
+		});
+
+		it("should not navigate past the first item with ArrowUp", async () => {
+			const user = userEvent.setup();
+			render(<RecoveryFAQ items={SAMPLE} />);
+
+			const buttons = screen.getAllByRole("button");
+			buttons[0].focus();
+			await user.keyboard("{ArrowUp}");
+			expect(buttons[0]).toHaveFocus();
+		});
+
+		it("should not navigate past the last item with ArrowDown", async () => {
+			const user = userEvent.setup();
+			render(<RecoveryFAQ items={SAMPLE} />);
+
+			const buttons = screen.getAllByRole("button");
+			const lastIndex = buttons.length - 1;
+			buttons[lastIndex].focus();
+			await user.keyboard("{ArrowDown}");
+			expect(buttons[lastIndex]).toHaveFocus();
+		});
+
+		it("should handle single item keyboard navigation", async () => {
+			const user = userEvent.setup();
+			render(<RecoveryFAQ items={[SAMPLE[0]]} />);
+
+			const buttons = screen.getAllByRole("button");
+			buttons[0].focus();
+			await user.keyboard("{ArrowDown}");
+			expect(buttons[0]).toHaveFocus();
+			await user.keyboard("{ArrowUp}");
+			expect(buttons[0]).toHaveFocus();
+		});
+
+		it("should expand item on Enter", async () => {
+			const user = userEvent.setup();
+			render(<RecoveryFAQ items={SAMPLE} />);
+
+			const buttons = screen.getAllByRole("button");
+			buttons[0].focus();
+			await user.keyboard("{Enter}");
+			expect(buttons[0]).toHaveAttribute("aria-expanded", "true");
+		});
+
+		it("should collapse item on Enter when already open", async () => {
+			const user = userEvent.setup();
+			render(<RecoveryFAQ items={SAMPLE} />);
+
+			const buttons = screen.getAllByRole("button");
+			buttons[0].focus();
+			await user.keyboard("{Enter}");
+			expect(buttons[0]).toHaveAttribute("aria-expanded", "true");
+			await user.keyboard("{Enter}");
+			expect(buttons[0]).toHaveAttribute("aria-expanded", "false");
+		});
 	});
 });

--- a/src/components/recovery/__tests__/RecoveryTimelineList.test.tsx
+++ b/src/components/recovery/__tests__/RecoveryTimelineList.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import {
 	mockRecoveryEvents,
 	mockRecoveryTimelineCompleted,
@@ -399,7 +400,177 @@ describe("RecoveryTimelineList", () => {
 		});
 	});
 
-	describe("Integration scenarios", () => {
+	describe("Keyboard navigation", () => {
+	it("should navigate down with ArrowDown", async () => {
+		const user = userEvent.setup();
+		render(
+			<RecoveryTimelineList
+				events={mockRecoveryEvents}
+				onEventClick={mockOnEventClick}
+			/>,
+		);
+
+		const buttons = screen.getAllByRole("button");
+		buttons[0].focus();
+		await user.keyboard("{ArrowDown}");
+		expect(buttons[1]).toHaveFocus();
+	});
+
+	it("should navigate up with ArrowUp", async () => {
+		const user = userEvent.setup();
+		render(
+			<RecoveryTimelineList
+				events={mockRecoveryEvents}
+				onEventClick={mockOnEventClick}
+			/>,
+		);
+
+		const buttons = screen.getAllByRole("button");
+		buttons[1].focus();
+		await user.keyboard("{ArrowUp}");
+		expect(buttons[0]).toHaveFocus();
+	});
+
+	it("should navigate to first event with Home", async () => {
+		const user = userEvent.setup();
+		render(
+			<RecoveryTimelineList
+				events={mockRecoveryEvents}
+				onEventClick={mockOnEventClick}
+			/>,
+		);
+
+		const buttons = screen.getAllByRole("button");
+		const lastIndex = buttons.length - 1;
+		buttons[lastIndex].focus();
+		await user.keyboard("{Home}");
+		expect(buttons[0]).toHaveFocus();
+	});
+
+	it("should navigate to last event with End", async () => {
+		const user = userEvent.setup();
+		render(
+			<RecoveryTimelineList
+				events={mockRecoveryEvents}
+				onEventClick={mockOnEventClick}
+			/>,
+		);
+
+		const buttons = screen.getAllByRole("button");
+		const lastIndex = buttons.length - 1;
+		buttons[0].focus();
+		await user.keyboard("{End}");
+		expect(buttons[lastIndex]).toHaveFocus();
+	});
+
+	it("should trigger onEventClick on Enter", async () => {
+		const user = userEvent.setup();
+		render(
+			<RecoveryTimelineList
+				events={mockRecoveryEvents}
+				onEventClick={mockOnEventClick}
+			/>,
+		);
+
+		const buttons = screen.getAllByRole("button");
+		buttons[0].focus();
+		await user.keyboard("{Enter}");
+		expect(mockOnEventClick).toHaveBeenCalledWith(mockRecoveryEvents[0]);
+	});
+
+	it("should trigger onEventClick on Space", async () => {
+		const user = userEvent.setup();
+		render(
+			<RecoveryTimelineList
+				events={mockRecoveryEvents}
+				onEventClick={mockOnEventClick}
+			/>,
+		);
+
+		const buttons = screen.getAllByRole("button");
+		buttons[0].focus();
+		await user.keyboard(" ");
+		expect(mockOnEventClick).toHaveBeenCalledWith(mockRecoveryEvents[0]);
+	});
+
+	it("should not navigate past the first event with ArrowUp", async () => {
+		const user = userEvent.setup();
+		render(
+			<RecoveryTimelineList
+				events={mockRecoveryEvents}
+				onEventClick={mockOnEventClick}
+			/>,
+		);
+
+		const buttons = screen.getAllByRole("button");
+		buttons[0].focus();
+		await user.keyboard("{ArrowUp}");
+		expect(buttons[0]).toHaveFocus();
+	});
+
+	it("should not navigate past the last event with ArrowDown", async () => {
+		const user = userEvent.setup();
+		render(
+			<RecoveryTimelineList
+				events={mockRecoveryEvents}
+				onEventClick={mockOnEventClick}
+			/>,
+		);
+
+		const buttons = screen.getAllByRole("button");
+		const lastIndex = buttons.length - 1;
+		buttons[lastIndex].focus();
+		await user.keyboard("{ArrowDown}");
+		expect(buttons[lastIndex]).toHaveFocus();
+	});
+
+	it("should apply focus ring on focused event button", () => {
+		const { container } = render(
+			<RecoveryTimelineList
+				events={mockRecoveryEvents}
+				onEventClick={mockOnEventClick}
+			/>,
+		);
+
+		const buttons = container.querySelectorAll("button");
+		buttons[0].focus();
+		expect(buttons[0]).toHaveClass("ring-2");
+	});
+
+	it("should handle single event keyboard navigation", async () => {
+		const user = userEvent.setup();
+		render(
+			<RecoveryTimelineList
+				events={[mockRecoveryEvents[0]]}
+				onEventClick={mockOnEventClick}
+			/>,
+		);
+
+		const buttons = screen.getAllByRole("button");
+		buttons[0].focus();
+		await user.keyboard("{ArrowDown}");
+		expect(buttons[0]).toHaveFocus();
+		await user.keyboard("{ArrowUp}");
+		expect(buttons[0]).toHaveFocus();
+	});
+
+	it("should have accessible data-testid on event buttons", () => {
+		render(
+			<RecoveryTimelineList
+				events={mockRecoveryEvents}
+				onEventClick={mockOnEventClick}
+			/>,
+		);
+
+		mockRecoveryEvents.forEach((_, index) => {
+			expect(
+				screen.getByTestId(`recovery-event-${index}`),
+			).toBeInTheDocument();
+		});
+	});
+});
+
+describe("Integration scenarios", () => {
 		it("should display complete recovery workflow", () => {
 			render(
 				<RecoveryTimelineList

--- a/src/types/recovery.ts
+++ b/src/types/recovery.ts
@@ -60,6 +60,13 @@ export interface RecoveryTimelineEventProps {
 	isFirst?: boolean;
 	onClick?: () => void;
 	className?: string;
+	focused?: boolean;
+	tabIndex?: number;
+	onKeyDown?: (e: React.KeyboardEvent) => void;
+	eventRef?: React.Ref<HTMLButtonElement>;
+	testId?: string;
+	onFocus?: () => void;
+	onBlur?: () => void;
 }
 
 export interface RecoveryTimelineListProps {


### PR DESCRIPTION
Closes #315

---

## Summary

Adds full keyboard navigation support to the Recovery UI components, following the existing WalletTable keyboard navigation pattern.

## Changes

### RecoveryTimelineList
- ArrowUp/ArrowDown: navigate between timeline events
- Home/End: jump to first/last event
- Enter/Space: activate selected event
- Focus ring (ring-2 ring-blue-500) on focused event buttons
- data-testid attributes for testing

### RecoveryFAQ
- ArrowUp/ArrowDown: navigate between FAQ items
- Home/End: jump to first/last item
- Enter/Space: toggle item (native button behavior)
- Focus ring on focused items

### Types
- Extended RecoveryTimelineEventProps with keyboard navigation props

### Tests
- 11 new keyboard navigation tests for RecoveryTimelineList
- 9 new keyboard navigation tests for RecoveryFAQ

## Acceptance Criteria
- [x] Behavior is covered by tests
- [x] No regressions in closely related user or API flows
- [x] Follows existing patterns (WalletTable keyboard nav pattern)
- [x] Handles edge cases (single items, boundary stops, blur)