### PR TITLE
feat(analytics): wire analytics page to backend API via useAnalyticsM…

### DIFF
--- a/src/app/dashboard/analytics/page.tsx
+++ b/src/app/dashboard/analytics/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { AnalyticsChart } from "@/components/analytics/AnalyticsChart";
+import { AnalyticsEmptyState } from "@/components/analytics/AnalyticsEmptyState";
 import {
 	AnalyticsHeader,
 	type DateRange,
@@ -10,7 +11,7 @@ import { AnalyticsLoadingSkeleton } from "@/components/analytics/AnalyticsLoadin
 import { MetricsCards } from "@/components/analytics/MetricsCards";
 import { TopAssetsTable } from "@/components/analytics/TopAssetsTable";
 import { ErrorState } from "@/components/ui/ErrorState";
-import { useAnalytics } from "@/hooks/useAnalytics";
+import { useAnalyticsMetrics } from "@/hooks/useAnalyticsMetrics";
 import { useAnalyticsTracking } from "@/hooks/useAnalyticsTracking";
 
 export default function AnalyticsPage() {
@@ -23,7 +24,9 @@ export default function AnalyticsPage() {
 			to: to.toISOString().slice(0, 10),
 		};
 	});
-	const { data, isLoading, isError, error, refetch } = useAnalytics();
+
+	const { data, isLoading, isEmpty, isError, error, refetch } =
+		useAnalyticsMetrics(range);
 	const { track } = useAnalyticsTracking("analytics");
 
 	function handleRangeChange(newRange: DateRange) {
@@ -35,13 +38,27 @@ export default function AnalyticsPage() {
 		return <AnalyticsLoadingSkeleton />;
 	}
 
-	if (isError || !data) {
+	if (isError) {
 		return (
 			<ErrorState
 				title="Failed to load analytics"
 				description={error ?? "An unexpected error occurred. Please try again."}
 				retry={{ onRetry: refetch }}
 			/>
+		);
+	}
+
+	if (isEmpty || !data) {
+		return (
+			<div className="space-y-6">
+				<AnalyticsHeader range={range} onRangeChange={handleRangeChange} />
+				<AnalyticsEmptyState
+					action={{
+						label: "Refresh",
+						onClick: refetch,
+					}}
+				/>
+			</div>
 		);
 	}
 


### PR DESCRIPTION
…etrics

- Replace useAnalytics (mock-only) with useAnalyticsMetrics in analytics page
- useAnalyticsMetrics fetches from real backend when NEXT_PUBLIC_MUX_API_URL is set, falls back to mock data otherwise (no regression in dev)
- Handle isEmpty state: show AnalyticsEmptyState when API returns no data
- Preserve full error state via ErrorState component
- Date range is passed to hook so re-fetches on range changes
- Existing useAnalyticsMetrics tests cover all states (loading, success, empty, error, API fallback, range changes, refetch)
closes #281 