### PR TITLE
Feature/console hardening batch

### DIFF
--- a/src/components/ui/ConfirmRevokeDialog.tsx
+++ b/src/components/ui/ConfirmRevokeDialog.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export interface ConfirmRevokeDialogProps {
+	open: boolean;
+	keyLabel?: string;
+	isPending?: boolean;
+	onConfirm: () => void;
+	onCancel: () => void;
+	className?: string;
+}
+
+/**
+ * Confirmation dialog shown before revoking an API key, so a stray click
+ * can't destroy a credential without an explicit second step.
+ */
+export function ConfirmRevokeDialog({
+	open,
+	keyLabel,
+	isPending = false,
+	onConfirm,
+	onCancel,
+	className,
+}: ConfirmRevokeDialogProps) {
+	const confirmRef = useRef<HTMLButtonElement>(null);
+
+	useEffect(() => {
+		if (open) confirmRef.current?.focus();
+	}, [open]);
+
+	useEffect(() => {
+		if (!open) return;
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key === "Escape") onCancel();
+		};
+		window.addEventListener("keydown", onKeyDown);
+		return () => window.removeEventListener("keydown", onKeyDown);
+	}, [open, onCancel]);
+
+	if (!open) return null;
+
+	return (
+		<div
+			className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+			data-testid="confirm-revoke-overlay"
+			onClick={onCancel}
+		>
+			<div
+				role="alertdialog"
+				aria-modal="true"
+				aria-labelledby="confirm-revoke-title"
+				aria-describedby="confirm-revoke-description"
+				data-testid="confirm-revoke-dialog"
+				className={cn(
+					"w-full max-w-sm rounded-lg border bg-background p-4 shadow-lg",
+					className,
+				)}
+				onClick={(e) => e.stopPropagation()}
+			>
+				<h2 id="confirm-revoke-title" className="text-sm font-semibold">
+					Revoke API key?
+				</h2>
+				<p
+					id="confirm-revoke-description"
+					className="mt-1 text-sm text-muted-foreground"
+				>
+					{keyLabel
+						? `This will immediately revoke "${keyLabel}". Any requests using it will start failing.`
+						: "This will immediately revoke the key. Any requests using it will start failing."}{" "}
+					This action cannot be undone.
+				</p>
+				<div className="mt-4 flex justify-end gap-2">
+					<Button variant="outline" onClick={onCancel} disabled={isPending}>
+						Cancel
+					</Button>
+					<Button
+						ref={confirmRef}
+						variant="destructive"
+						onClick={onConfirm}
+						disabled={isPending}
+					>
+						{isPending ? "Revoking…" : "Revoke key"}
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/ui/NetworkMismatchBanner.tsx
+++ b/src/components/ui/NetworkMismatchBanner.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface NetworkMismatchBannerProps {
+	/** Network the UI is currently configured for */
+	uiNetwork: "testnet" | "mainnet";
+	/** Network the backend/API is actually responding on */
+	backendNetwork: "testnet" | "mainnet";
+	className?: string;
+}
+
+/**
+ * Warns the user when the UI's selected network and the backend's active
+ * network disagree, so they don't act on data from the wrong network.
+ */
+export function NetworkMismatchBanner({
+	uiNetwork,
+	backendNetwork,
+	className,
+}: NetworkMismatchBannerProps) {
+	if (uiNetwork === backendNetwork) return null;
+
+	return (
+		<div
+			role="alert"
+			data-testid="network-mismatch-banner"
+			className={cn(
+				"flex items-center gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive",
+				className,
+			)}
+		>
+			<AlertTriangle className="size-4 shrink-0" aria-hidden="true" />
+			<span>
+				Network mismatch: the console is set to{" "}
+				<strong>{uiNetwork}</strong> but the backend is responding on{" "}
+				<strong>{backendNetwork}</strong>. Data shown may be inaccurate.
+			</span>
+		</div>
+	);
+}

--- a/src/components/ui/__tests__/ConfirmRevokeDialog.test.tsx
+++ b/src/components/ui/__tests__/ConfirmRevokeDialog.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ConfirmRevokeDialog } from "../ConfirmRevokeDialog";
+
+describe("ConfirmRevokeDialog", () => {
+	it("renders nothing when closed", () => {
+		render(
+			<ConfirmRevokeDialog
+				open={false}
+				onConfirm={vi.fn()}
+				onCancel={vi.fn()}
+			/>,
+		);
+		expect(screen.queryByTestId("confirm-revoke-dialog")).toBeNull();
+	});
+
+	it("renders an alertdialog with key label when open", () => {
+		render(
+			<ConfirmRevokeDialog
+				open
+				keyLabel="prod-key-1"
+				onConfirm={vi.fn()}
+				onCancel={vi.fn()}
+			/>,
+		);
+		const dialog = screen.getByTestId("confirm-revoke-dialog");
+		expect(dialog).toBeInTheDocument();
+		expect(dialog.textContent).toContain("prod-key-1");
+	});
+
+	it("calls onConfirm when the revoke button is clicked", () => {
+		const onConfirm = vi.fn();
+		render(
+			<ConfirmRevokeDialog open onConfirm={onConfirm} onCancel={vi.fn()} />,
+		);
+		fireEvent.click(screen.getByRole("button", { name: /revoke key/i }));
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls onCancel when Escape is pressed", () => {
+		const onCancel = vi.fn();
+		render(
+			<ConfirmRevokeDialog open onConfirm={vi.fn()} onCancel={onCancel} />,
+		);
+		fireEvent.keyDown(window, { key: "Escape" });
+		expect(onCancel).toHaveBeenCalledTimes(1);
+	});
+
+	it("disables both buttons while pending", () => {
+		render(
+			<ConfirmRevokeDialog
+				open
+				isPending
+				onConfirm={vi.fn()}
+				onCancel={vi.fn()}
+			/>,
+		);
+		expect(screen.getByRole("button", { name: /cancel/i })).toBeDisabled();
+		expect(
+			screen.getByRole("button", { name: /revoking/i }),
+		).toBeDisabled();
+	});
+});

--- a/src/components/ui/__tests__/NetworkMismatchBanner.test.tsx
+++ b/src/components/ui/__tests__/NetworkMismatchBanner.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { NetworkMismatchBanner } from "../NetworkMismatchBanner";
+
+describe("NetworkMismatchBanner", () => {
+	it("renders nothing when networks match", () => {
+		render(
+			<NetworkMismatchBanner uiNetwork="testnet" backendNetwork="testnet" />,
+		);
+		expect(screen.queryByTestId("network-mismatch-banner")).toBeNull();
+	});
+
+	it("renders an alert when networks mismatch", () => {
+		render(
+			<NetworkMismatchBanner uiNetwork="mainnet" backendNetwork="testnet" />,
+		);
+		const banner = screen.getByTestId("network-mismatch-banner");
+		expect(banner).toBeInTheDocument();
+		expect(banner).toHaveAttribute("role", "alert");
+		expect(banner.textContent).toContain("mainnet");
+		expect(banner.textContent).toContain("testnet");
+	});
+});

--- a/src/hooks/__tests__/usePendingAction.test.ts
+++ b/src/hooks/__tests__/usePendingAction.test.ts
@@ -1,0 +1,56 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { usePendingAction } from "../usePendingAction";
+
+describe("usePendingAction", () => {
+	it("starts not pending", () => {
+		const { result } = renderHook(() =>
+			usePendingAction(async () => "done"),
+		);
+		expect(result.current.isPending).toBe(false);
+	});
+
+	it("sets isPending true while the action runs, false after", async () => {
+		let resolveFn: (v: string) => void = () => {};
+		const action = vi.fn(
+			() =>
+				new Promise<string>((resolve) => {
+					resolveFn = resolve;
+				}),
+		);
+		const { result } = renderHook(() => usePendingAction(action));
+
+		let runPromise: Promise<string | undefined>;
+		act(() => {
+			runPromise = result.current.run();
+		});
+		expect(result.current.isPending).toBe(true);
+
+		await act(async () => {
+			resolveFn("done");
+			await runPromise;
+		});
+		expect(result.current.isPending).toBe(false);
+	});
+
+	it("ignores a second call while already pending", async () => {
+		let resolveFn: (v: string) => void = () => {};
+		const action = vi.fn(
+			() =>
+				new Promise<string>((resolve) => {
+					resolveFn = resolve;
+				}),
+		);
+		const { result } = renderHook(() => usePendingAction(action));
+
+		act(() => {
+			result.current.run();
+		});
+		await act(async () => {
+			await result.current.run();
+		});
+
+		expect(action).toHaveBeenCalledTimes(1);
+		resolveFn("done");
+	});
+});

--- a/src/hooks/usePendingAction.ts
+++ b/src/hooks/usePendingAction.ts
@@ -1,0 +1,27 @@
+import { useCallback, useState } from "react";
+
+/**
+ * Tracks in-flight state for a destructive/async action so callers can
+ * disable the triggering button while a request is pending, preventing
+ * duplicate submissions.
+ */
+export function usePendingAction<Args extends unknown[], Result>(
+	action: (...args: Args) => Promise<Result>,
+) {
+	const [isPending, setIsPending] = useState(false);
+
+	const run = useCallback(
+		async (...args: Args) => {
+			if (isPending) return undefined;
+			setIsPending(true);
+			try {
+				return await action(...args);
+			} finally {
+				setIsPending(false);
+			}
+		},
+		[action, isPending],
+	);
+
+	return { run, isPending };
+}

--- a/src/lib/__tests__/fetchWithRetry.test.ts
+++ b/src/lib/__tests__/fetchWithRetry.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchWithRetry } from "../fetchWithRetry";
+
+describe("fetchWithRetry", () => {
+	beforeEach(() => {
+		vi.stubGlobal("fetch", vi.fn());
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	it("returns immediately on success", async () => {
+		const ok = new Response("{}", { status: 200 });
+		(fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(ok);
+
+		const res = await fetchWithRetry("/api/thing", { baseDelayMs: 0 });
+		expect(res.status).toBe(200);
+		expect(fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("retries on 500 then succeeds", async () => {
+		const fail = new Response("err", { status: 500 });
+		const ok = new Response("{}", { status: 200 });
+		(fetch as unknown as ReturnType<typeof vi.fn>)
+			.mockResolvedValueOnce(fail)
+			.mockResolvedValueOnce(ok);
+
+		const res = await fetchWithRetry("/api/thing", {
+			baseDelayMs: 0,
+			retries: 2,
+		});
+		expect(res.status).toBe(200);
+		expect(fetch).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not retry on 4xx (non-429)", async () => {
+		const fail = new Response("bad", { status: 400 });
+		(fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+			fail,
+		);
+
+		const res = await fetchWithRetry("/api/thing", { baseDelayMs: 0 });
+		expect(res.status).toBe(400);
+		expect(fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("throws after exhausting retries", async () => {
+		(fetch as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+			new Error("network down"),
+		);
+
+		await expect(
+			fetchWithRetry("/api/thing", { baseDelayMs: 0, retries: 2 }),
+		).rejects.toThrow("network down");
+		expect(fetch).toHaveBeenCalledTimes(3);
+	});
+});

--- a/src/lib/fetchWithRetry.ts
+++ b/src/lib/fetchWithRetry.ts
@@ -1,0 +1,37 @@
+export interface FetchWithRetryOptions {
+	retries?: number;
+	baseDelayMs?: number;
+}
+
+/**
+ * Fetch wrapper for idempotent GET requests that retries transient
+ * failures (network errors, 5xx, 429) with exponential backoff.
+ */
+export async function fetchWithRetry(
+	url: string,
+	options: FetchWithRetryOptions = {},
+): Promise<Response> {
+	const { retries = 3, baseDelayMs = 300 } = options;
+
+	let lastError: unknown;
+
+	for (let attempt = 0; attempt <= retries; attempt++) {
+		try {
+			const res = await fetch(url, { method: "GET" });
+			if (res.ok) return res;
+			if (res.status !== 429 && res.status < 500) return res;
+			lastError = new Error(`HTTP ${res.status}`);
+		} catch (err) {
+			lastError = err;
+		}
+
+		if (attempt < retries) {
+			const delay = baseDelayMs * 2 ** attempt;
+			await new Promise((resolve) => setTimeout(resolve, delay));
+		}
+	}
+
+	throw lastError instanceof Error
+		? lastError
+		: new Error("fetchWithRetry: request failed");
+}


### PR DESCRIPTION
closes #524 
closes #525
closes #526 
closes #527 

The Mux frontend should improve revoke dialog. This issue covers 'Add confirm dialog before revoke API key' so the developer console stays usable, accessible, and correctly wired to backend APIs across testnet and mainnet.
Tasks
Implement revoke dialog in the relevant Next.js page or component
Reuse existing UI primitives and hooks where possible
Add or update Vitest/Testing Library coverage for the behavior
Verify the flow manually on desktop and a narrow mobile viewport
