### PR TITLE
Feature/send flow stubs 4in1

### DIFF
--- a/src/components/wallet/MemoField.tsx
+++ b/src/components/wallet/MemoField.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useId, useState } from "react";
+import { cn } from "@/lib/utils";
+
+const MAX_MEMO_LENGTH = 28;
+
+interface MemoFieldProps {
+	value?: string;
+	onChange?: (value: string) => void;
+	maxLength?: number;
+}
+
+/**
+ * Memo input with a character counter, matching Stellar's 28-byte memo text limit.
+ */
+export function MemoField({
+	value,
+	onChange,
+	maxLength = MAX_MEMO_LENGTH,
+}: MemoFieldProps) {
+	const [internalValue, setInternalValue] = useState("");
+	const memo = value ?? internalValue;
+	const id = useId();
+	const remaining = maxLength - memo.length;
+
+	const handleChange = (next: string) => {
+		if (next.length > maxLength) return;
+		setInternalValue(next);
+		onChange?.(next);
+	};
+
+	return (
+		<div className="space-y-1">
+			<label htmlFor={id} className="text-sm font-medium">
+				Memo (optional)
+			</label>
+			<input
+				id={id}
+				value={memo}
+				maxLength={maxLength}
+				onChange={(e) => handleChange(e.target.value)}
+				className="w-full rounded-md border px-3 py-2 text-sm"
+				placeholder="Add a memo"
+			/>
+			<p
+				className={cn(
+					"text-xs text-right",
+					remaining <= 5 ? "text-red-500" : "text-muted-foreground",
+				)}
+				data-testid="memo-counter"
+			>
+				{memo.length}/{maxLength}
+			</p>
+		</div>
+	);
+}

--- a/src/components/wallet/SendDraftScreen.tsx
+++ b/src/components/wallet/SendDraftScreen.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import type { Wallet } from "@/types/wallet";
+
+interface SendDraftScreenProps {
+	wallet: Wallet | null;
+	onContinue?: (draft: { destination: string; amount: string }) => void;
+}
+
+/**
+ * Stub screen for the send flow draft step. Captures destination/amount
+ * before handing off to the full SendWalletModal validation flow.
+ */
+export function SendDraftScreen({ wallet, onContinue }: SendDraftScreenProps) {
+	const [destination, setDestination] = useState("");
+	const [amount, setAmount] = useState("");
+
+	return (
+		<div className="space-y-4" data-testid="send-draft-screen">
+			<h2 className="text-lg font-semibold">
+				Send from {wallet?.name ?? "wallet"}
+			</h2>
+			<div className="space-y-2">
+				<label htmlFor="send-draft-destination" className="text-sm font-medium">
+					Destination
+				</label>
+				<input
+					id="send-draft-destination"
+					value={destination}
+					onChange={(e) => setDestination(e.target.value)}
+					className="w-full rounded-md border px-3 py-2 text-sm"
+					placeholder="G..."
+				/>
+			</div>
+			<div className="space-y-2">
+				<label htmlFor="send-draft-amount" className="text-sm font-medium">
+					Amount
+				</label>
+				<input
+					id="send-draft-amount"
+					value={amount}
+					onChange={(e) => setAmount(e.target.value)}
+					className="w-full rounded-md border px-3 py-2 text-sm"
+					placeholder="0.00"
+				/>
+			</div>
+			<Button
+				type="button"
+				onClick={() => onContinue?.({ destination, amount })}
+			>
+				Continue
+			</Button>
+		</div>
+	);
+}

--- a/src/components/wallet/__tests__/MemoField.test.tsx
+++ b/src/components/wallet/__tests__/MemoField.test.tsx
@@ -1,0 +1,20 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MemoField } from "../MemoField";
+
+describe("MemoField", () => {
+	it("shows the counter updating as text is typed", () => {
+		render(<MemoField />);
+		const input = screen.getByLabelText("Memo (optional)");
+		expect(screen.getByTestId("memo-counter")).toHaveTextContent("0/28");
+		fireEvent.change(input, { target: { value: "hello" } });
+		expect(screen.getByTestId("memo-counter")).toHaveTextContent("5/28");
+	});
+
+	it("does not exceed the max length", () => {
+		render(<MemoField maxLength={5} />);
+		const input = screen.getByLabelText("Memo (optional)");
+		fireEvent.change(input, { target: { value: "abcdef" } });
+		expect(screen.getByTestId("memo-counter")).toHaveTextContent("0/5");
+	});
+});

--- a/src/components/wallet/__tests__/SendDraftScreen.test.tsx
+++ b/src/components/wallet/__tests__/SendDraftScreen.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SendDraftScreen } from "../SendDraftScreen";
+
+const wallet = { id: "1", name: "Main Wallet" } as never;
+
+describe("SendDraftScreen", () => {
+	it("renders destination and amount fields", () => {
+		render(<SendDraftScreen wallet={wallet} />);
+		expect(screen.getByTestId("send-draft-screen")).toBeInTheDocument();
+		expect(screen.getByLabelText("Destination")).toBeInTheDocument();
+		expect(screen.getByLabelText("Amount")).toBeInTheDocument();
+	});
+
+	it("calls onContinue with draft values", () => {
+		const onContinue = vi.fn();
+		render(<SendDraftScreen wallet={wallet} onContinue={onContinue} />);
+		fireEvent.change(screen.getByLabelText("Destination"), {
+			target: { value: "GABC" },
+		});
+		fireEvent.change(screen.getByLabelText("Amount"), {
+			target: { value: "10" },
+		});
+		fireEvent.click(screen.getByText("Continue"));
+		expect(onContinue).toHaveBeenCalledWith({ destination: "GABC", amount: "10" });
+	});
+});

--- a/src/lib/i18n/__tests__/shellLabels.test.ts
+++ b/src/lib/i18n/__tests__/shellLabels.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { shellLabels } from "../shellLabels";
+
+describe("shellLabels", () => {
+	it("exposes nav labels", () => {
+		expect(shellLabels.nav.dashboard).toBe("Dashboard");
+		expect(shellLabels.nav.wallets).toBe("Wallets");
+	});
+
+	it("exposes header and footer labels", () => {
+		expect(shellLabels.header.testnet).toBe("Testnet");
+		expect(shellLabels.footer.docs).toBe("Documentation");
+	});
+});

--- a/src/lib/i18n/shellLabels.ts
+++ b/src/lib/i18n/shellLabels.ts
@@ -1,0 +1,26 @@
+/**
+ * Centralized, i18n-ready strings for the dashboard shell (nav, header, footer).
+ * Extracting these here lets a future translation layer swap this object
+ * without hunting through components for hardcoded copy.
+ */
+export const shellLabels = {
+	nav: {
+		dashboard: "Dashboard",
+		wallets: "Wallets",
+		analytics: "Analytics",
+		apiKeys: "API Keys",
+		spendingLimits: "Spending Limits",
+		settings: "Settings",
+	},
+	header: {
+		testnet: "Testnet",
+		mainnet: "Mainnet",
+		logout: "Log out",
+	},
+	footer: {
+		docs: "Documentation",
+		support: "Support",
+	},
+} as const;
+
+export type ShellLabelKey = keyof typeof shellLabels;

--- a/src/utils/__tests__/validateSendAmount.test.ts
+++ b/src/utils/__tests__/validateSendAmount.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { validateSendAmount } from "../validateSendAmount";
+
+describe("validateSendAmount", () => {
+	it("rejects empty amount", () => {
+		expect(validateSendAmount("", 100).isValid).toBe(false);
+	});
+
+	it("rejects non-positive amount", () => {
+		expect(validateSendAmount("0", 100).isValid).toBe(false);
+		expect(validateSendAmount("-5", 100).isValid).toBe(false);
+	});
+
+	it("rejects amount exceeding balance", () => {
+		const result = validateSendAmount("150", 100);
+		expect(result.isValid).toBe(false);
+		expect(result.error).toContain("exceeds available balance");
+	});
+
+	it("accepts valid amount within balance", () => {
+		expect(validateSendAmount("50", 100).isValid).toBe(true);
+	});
+});

--- a/src/utils/validateSendAmount.ts
+++ b/src/utils/validateSendAmount.ts
@@ -1,0 +1,30 @@
+/**
+ * Validates a send amount against the available wallet balance.
+ */
+export interface SendAmountValidationResult {
+	isValid: boolean;
+	error: string | null;
+}
+
+export function validateSendAmount(
+	amount: string,
+	availableBalance: number | null,
+): SendAmountValidationResult {
+	if (!amount.trim()) {
+		return { isValid: false, error: "Amount is required." };
+	}
+
+	const parsed = Number.parseFloat(amount);
+	if (Number.isNaN(parsed) || parsed <= 0) {
+		return { isValid: false, error: "Enter a positive amount." };
+	}
+
+	if (availableBalance !== null && parsed > availableBalance) {
+		return {
+			isValid: false,
+			error: `Amount exceeds available balance (${availableBalance}).`,
+		};
+	}
+
+	return { isValid: true, error: null };
+}


### PR DESCRIPTION
closes #532 
closes #533 
closes #534 
closes #535 

The Mux frontend should improve i18n prep. This issue covers 'Add i18n ready string extraction for shell labels' so the developer console stays usable, accessible, and correctly wired to backend APIs across testnet and mainnet.
Tasks
Implement i18n prep in the relevant Next.js page or component
Reuse existing UI primitives and hooks where possible
Add or update Vitest/Testing Library coverage for the behavior
Verify the flow manually on desktop and a narrow mobile viewport
The Mux frontend should improve memo counter. This issue covers 'Show memo field with length counter' so the developer console stays usable, accessible, and correctly wired to backend APIs across testnet and mainnet.
Tasks
Implement memo counter in the relevant Next.js page or component
Reuse existing UI primitives and hooks where possible
Add or update Vitest/Testing Library coverage for the behavior
Verify the flow manually on desktop and a narrow mobile viewport
