### PR TITLE
Jobsunday002 a11y fixes

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -83,6 +83,12 @@ export default function RootLayout({
 			<body
 				className={`${inter.variable} ${jetbrainsMono.variable} antialiased`}
 			>
+				<a
+					href="#main-content"
+					className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-blue-600 focus:px-4 focus:py-2 focus:text-white"
+				>
+					Skip to content
+				</a>
 				<AuthProvider>
 					<ReactQueryProvider>
 						<ApiProvider>{children}</ApiProvider>

--- a/src/components/analytics/TopAssetsTable.tsx
+++ b/src/components/analytics/TopAssetsTable.tsx
@@ -21,7 +21,10 @@ export function TopAssetsTable({ assets }: TopAssetsTableProps) {
 		<>
 			<div className="rounded-xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
 				<div className="border-b border-zinc-200 px-4 py-4 sm:px-6 dark:border-zinc-800">
-					<h3 className="text-base font-semibold text-zinc-900 sm:text-lg dark:text-zinc-50">
+					<h3
+						id="top-assets-table-heading"
+						className="text-base font-semibold text-zinc-900 sm:text-lg dark:text-zinc-50"
+					>
 						Top Assets by Volume
 					</h3>
 					<p className="mt-0.5 text-sm text-zinc-500 dark:text-zinc-400">
@@ -30,7 +33,10 @@ export function TopAssetsTable({ assets }: TopAssetsTableProps) {
 				</div>
 
 				<div className="overflow-x-auto">
-					<table className="w-full min-w-[480px] text-sm">
+					<table
+						aria-labelledby="top-assets-table-heading"
+						className="w-full min-w-[480px] text-sm"
+					>
 						<thead>
 							<tr className="border-b border-zinc-100 dark:border-zinc-800">
 								<th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-zinc-500 sm:px-6 dark:text-zinc-400">

--- a/src/components/dashboard/ApiKeysTable.tsx
+++ b/src/components/dashboard/ApiKeysTable.tsx
@@ -328,7 +328,8 @@ export function ApiKeysTable({ initialKeys = mockApiKeys }: ApiKeysTableProps) {
 						/>
 					</div>
 				) : (
-					<Table>
+					<Table aria-label="API keys">
+						<caption className="sr-only">List of API keys with status and creation date</caption>
 						<TableHeader className="bg-zinc-50/50 dark:bg-zinc-900/50">
 							<TableRow>
 								<TableHead className="w-[200px] pl-6">Name</TableHead>

--- a/src/components/layouts/DashboardLayout.tsx
+++ b/src/components/layouts/DashboardLayout.tsx
@@ -108,7 +108,7 @@ function DashboardLayoutShell({ children }: DashboardLayoutProps) {
 					<TopNav onMenuClick={toggleSidebar} />
 
 					{/* Main */}
-					<main className="flex-1">
+					<main id="main-content" className="flex-1">
 						<div className="py-6">
 							<div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
 								{children}

--- a/src/components/layouts/TopNav.tsx
+++ b/src/components/layouts/TopNav.tsx
@@ -19,9 +19,10 @@ interface TopNavProps {
 }
 
 const networkLabel = { mainnet: "Mainnet", testnet: "Testnet" } as const;
+// Text colors darkened to -900 to meet WCAG AA (4.5:1) contrast against their badge backgrounds.
 const networkBadgeClass = {
-	mainnet: "bg-blue-100 text-blue-800",
-	testnet: "bg-amber-100 text-amber-800",
+	mainnet: "bg-blue-100 text-blue-900",
+	testnet: "bg-amber-100 text-amber-900",
 } as const;
 
 export function TopNav({ onMenuClick }: TopNavProps) {
@@ -108,13 +109,19 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 				{/* Right side actions */}
 				<div className="flex items-center gap-x-3 sm:gap-x-6">
 					{/* Network Switcher */}
-					<div className="flex items-center rounded-lg border border-gray-200 bg-gray-50 p-0.5 text-sm font-medium">
+					<div
+						role="group"
+						aria-label="Network selector"
+						className="flex items-center rounded-lg border border-gray-200 bg-gray-50 p-0.5 text-sm font-medium"
+					>
 						<button
 							type="button"
 							onClick={() => setNetwork("testnet")}
+							aria-pressed={network === "testnet"}
+							aria-label="Switch to Testnet"
 							className={`rounded-md px-3 py-1 transition-colors ${
 								network === "testnet"
-									? "bg-amber-100 text-amber-800"
+									? "bg-amber-100 text-amber-900"
 									: "text-gray-500 hover:text-gray-700"
 							}`}
 						>
@@ -123,9 +130,11 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 						<button
 							type="button"
 							onClick={() => setNetwork("mainnet")}
+							aria-pressed={network === "mainnet"}
+							aria-label="Switch to Mainnet"
 							className={`rounded-md px-3 py-1 transition-colors ${
 								network === "mainnet"
-									? "bg-blue-100 text-blue-800"
+									? "bg-blue-100 text-blue-900"
 									: "text-gray-500 hover:text-gray-700"
 							}`}
 						>

--- a/src/components/wallet/NetworkBadge.tsx
+++ b/src/components/wallet/NetworkBadge.tsx
@@ -7,11 +7,12 @@ interface NetworkBadgeProps {
 	className?: string;
 }
 
+// Text colors darkened to -900/-300 to meet WCAG AA (4.5:1) contrast against their badge backgrounds.
 const networkStyles: Record<WalletNetwork, string> = {
 	testnet:
-		"bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100 dark:bg-amber-900/30 dark:text-amber-400 dark:border-amber-800",
+		"bg-amber-100 text-amber-900 border-amber-200 hover:bg-amber-100 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-800",
 	mainnet:
-		"bg-blue-100 text-blue-800 border-blue-200 hover:bg-blue-100 dark:bg-blue-900/30 dark:text-blue-400 dark:border-blue-800",
+		"bg-blue-100 text-blue-900 border-blue-200 hover:bg-blue-100 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-800",
 };
 
 const networkLabels: Record<WalletNetwork, string> = {

--- a/src/components/wallet/WalletTable.tsx
+++ b/src/components/wallet/WalletTable.tsx
@@ -204,7 +204,10 @@ export function WalletTable({
 					<>
 						{/* Desktop Table View */}
 						<div className="hidden lg:block">
-							<Table>
+							<Table aria-label="Wallets">
+								<caption className="sr-only">
+									List of wallets with network, status, balance, and activity
+								</caption>
 								<TableHeader>
 									<TableRow className="hover:bg-transparent dark:hover:bg-transparent">
 										<TableHead>Address</TableHead>


### PR DESCRIPTION
closes #536 
closes #537 
closes #538 
closes #539 

The Mux frontend should improve table labels. This issue covers 'Ensure tables have captions or aria labels' so the developer console stays usable, accessible, and correctly wired to backend APIs across testnet and mainnet.
Tasks
Implement table labels in the relevant Next.js page or component
Reuse existing UI primitives and hooks where possible
Add or update Vitest/Testing Library coverage for the behavior
Verify the flow manually on desktop and a narrow mobile viewport

The Mux frontend should improve network selector a11y. This issue covers 'Pin down TopNav network selector accessibility name' so the developer console stays usable, accessible, and correctly wired to backend APIs across testnet and mainnet.
Tasks
Implement network selector a11y in the relevant Next.js page or component
Reuse existing UI primitives and hooks where possible
Add or update Vitest/Testing Library coverage for the behavior
Verify the flow manually on desktop and a narrow mobile viewport


