### PR TITLE
Wallets error/retry, network persistence + toggle, explorer links

### DIFF
--- a/src/app/dashboard/wallets/page.test.tsx
+++ b/src/app/dashboard/wallets/page.test.tsx
@@ -1,5 +1,28 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import WalletsPage from "@/app/dashboard/wallets/page";
+import type { Wallet } from "@/types/wallet";
+
+const mockWallet: Wallet = {
+	id: "wallet-001",
+	address: "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI",
+	network: "mainnet",
+	status: "active",
+	createdAt: new Date("2024-01-15T10:30:00Z"),
+	balance: "1,250.50 XLM",
+};
+
+function mockFetchOk(data: unknown) {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(data) }),
+	);
+}
+
+function mockFetchFail(status = 500) {
+	vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status }));
+}
 
 describe("WalletsPage (/dashboard/wallets)", () => {
 	let consoleSpy: ReturnType<typeof vi.spyOn>;
@@ -10,31 +33,24 @@ describe("WalletsPage (/dashboard/wallets)", () => {
 
 	afterEach(() => {
 		consoleSpy.mockRestore();
-		vi.resetModules();
-		vi.doUnmock("@/mock-data/wallets");
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
 	});
-
-	async function renderPage() {
-		const { default: WalletsPage } = await import(
-			"@/app/dashboard/wallets/page"
-		);
-		render(<WalletsPage />);
-	}
 
 	describe("analytics tracking", () => {
 		it("fires a page_view event for the wallets page on mount", async () => {
-			await renderPage();
-			expect(consoleSpy).toHaveBeenCalledWith(
-				"[analytics]",
-				"page_view",
-				{ page: "wallets" },
-			);
+			mockFetchOk([mockWallet]);
+			render(<WalletsPage />);
+			expect(consoleSpy).toHaveBeenCalledWith("[analytics]", "page_view", {
+				page: "wallets",
+			});
 		});
 	});
 
 	describe("page header", () => {
 		it("renders the heading and description", async () => {
-			await renderPage();
+			mockFetchOk([mockWallet]);
+			render(<WalletsPage />);
 			expect(
 				screen.getByRole("heading", { name: /wallet monitoring/i }),
 			).toBeInTheDocument();
@@ -44,30 +60,96 @@ describe("WalletsPage (/dashboard/wallets)", () => {
 		});
 	});
 
+	describe("loading state", () => {
+		it("shows a skeleton while wallets are loading", () => {
+			mockFetchOk([mockWallet]);
+			render(<WalletsPage />);
+			expect(screen.getAllByTestId("skeleton").length).toBeGreaterThan(0);
+			expect(screen.queryByRole("table")).not.toBeInTheDocument();
+		});
+	});
+
 	describe("with wallets data", () => {
 		it("renders the WalletTable", async () => {
-			await renderPage();
-			expect(screen.getByRole("table")).toBeInTheDocument();
+			mockFetchOk([mockWallet]);
+			render(<WalletsPage />);
+			await waitFor(() =>
+				expect(screen.getByRole("table")).toBeInTheDocument(),
+			);
 		});
 
-		it("does not render the EmptyState", async () => {
-			await renderPage();
+		it("does not render the EmptyState or ErrorState", async () => {
+			mockFetchOk([mockWallet]);
+			render(<WalletsPage />);
+			await waitFor(() =>
+				expect(screen.getByRole("table")).toBeInTheDocument(),
+			);
 			expect(
 				screen.queryByText(/you haven't added any wallets/i),
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByText(/failed to load wallets/i),
 			).not.toBeInTheDocument();
 		});
 	});
 
 	describe("empty state", () => {
 		it("renders the EmptyState when there are no wallets", async () => {
-			vi.resetModules();
-			vi.doMock("@/mock-data/wallets", () => ({ dummyWallets: [] }));
-			await renderPage();
-			expect(screen.getByText(/no wallets found/i)).toBeInTheDocument();
+			mockFetchOk([]);
+			render(<WalletsPage />);
+			await waitFor(() =>
+				expect(screen.getByText(/no wallets found/i)).toBeInTheDocument(),
+			);
 			expect(
 				screen.getByRole("button", { name: /add wallet/i }),
 			).toBeInTheDocument();
 			expect(screen.queryByRole("table")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("error state", () => {
+		it("renders an error message with a retry button when the fetch fails", async () => {
+			mockFetchFail(500);
+			render(<WalletsPage />);
+			await waitFor(() =>
+				expect(
+					screen.getByText(/failed to load wallets/i),
+				).toBeInTheDocument(),
+			);
+			expect(
+				screen.getByRole("button", { name: /retry/i }),
+			).toBeInTheDocument();
+			expect(screen.queryByRole("table")).not.toBeInTheDocument();
+			expect(
+				screen.queryByText(/no wallets found/i),
+			).not.toBeInTheDocument();
+		});
+
+		it("re-triggers the fetch when Retry is clicked and recovers", async () => {
+			const fetchMock = vi
+				.fn()
+				.mockResolvedValueOnce({ ok: false, status: 500 })
+				.mockResolvedValueOnce({
+					ok: true,
+					json: () => Promise.resolve([mockWallet]),
+				});
+			vi.stubGlobal("fetch", fetchMock);
+
+			const user = userEvent.setup();
+			render(<WalletsPage />);
+
+			await waitFor(() =>
+				expect(
+					screen.getByText(/failed to load wallets/i),
+				).toBeInTheDocument(),
+			);
+
+			await user.click(screen.getByRole("button", { name: /retry/i }));
+
+			await waitFor(() =>
+				expect(screen.getByRole("table")).toBeInTheDocument(),
+			);
+			expect(fetchMock).toHaveBeenCalledTimes(2);
 		});
 	});
 });

--- a/src/app/dashboard/wallets/page.tsx
+++ b/src/app/dashboard/wallets/page.tsx
@@ -3,21 +3,26 @@
 import { useState } from "react";
 import { AddWalletModal } from "@/components/wallet/AddWalletModal";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { ErrorState } from "@/components/ui/ErrorState";
 import { PageHeader } from "@/components/ui/PageHeader";
+import { WalletTableSkeleton } from "@/components/ui/Skeleton";
 import { WalletTable } from "@/components/wallet/WalletTable";
 import { useAnalyticsTracking } from "@/hooks/useAnalyticsTracking";
-import { dummyWallets } from "@/mock-data/wallets";
+import { useWallets } from "@/hooks/useWallets";
 import type { Wallet } from "@/types/wallet";
 
 export default function WalletsPage() {
-	const [wallets, setWallets] = useState<Wallet[]>(dummyWallets);
+	const { wallets: fetchedWallets, loading, error, refetch } = useWallets();
+	const [addedWallets, setAddedWallets] = useState<Wallet[]>([]);
 	const [isAddOpen, setIsAddOpen] = useState(false);
 	useAnalyticsTracking("wallets");
+
+	const wallets = [...addedWallets, ...fetchedWallets];
 
 	const openAddWallet = () => setIsAddOpen(true);
 
 	const handleAdd = (wallet: Wallet) => {
-		setWallets((prev) => [wallet, ...prev]);
+		setAddedWallets((prev) => [wallet, ...prev]);
 		setIsAddOpen(false);
 	};
 
@@ -28,7 +33,15 @@ export default function WalletsPage() {
 				description="Track and manage your Stellar wallets"
 			/>
 
-			{wallets.length > 0 ? (
+			{loading ? (
+				<WalletTableSkeleton />
+			) : error && wallets.length === 0 ? (
+				<ErrorState
+					title="Failed to load wallets"
+					description={`${error} Check your connection and try again.`}
+					retry={{ label: "Retry", onRetry: refetch }}
+				/>
+			) : wallets.length > 0 ? (
 				<WalletTable wallets={wallets} onAddWallet={openAddWallet} />
 			) : (
 				<EmptyState

--- a/src/app/wallet/page.tsx
+++ b/src/app/wallet/page.tsx
@@ -8,6 +8,7 @@ import TransactionsTable from "@/components/TransactionsTable/TransactionsTable"
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { ErrorState } from "@/components/ui/ErrorState";
+import { ExplorerLink } from "@/components/ui/ExplorerLink";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { NetworkBadge } from "@/components/wallet/NetworkBadge";
 import ReceiveWalletModal from "@/components/wallet/ReceiveWalletModal";
@@ -184,6 +185,14 @@ function WalletPageContent() {
 												<Copy className="h-4 w-4" aria-hidden="true" />
 											)}
 										</Button>
+										<ExplorerLink
+											address={wallet.address}
+											network={wallet.network}
+											type="account"
+											size="icon-sm"
+											showIcon
+											title="View on Stellar Explorer"
+										/>
 									</div>
 									{copyError && (
 										<p role="alert" className="mt-1 text-xs text-red-600">

--- a/src/components/layouts/TopNav.tsx
+++ b/src/components/layouts/TopNav.tsx
@@ -108,21 +108,21 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 
 				{/* Right side actions */}
 				<div className="flex items-center gap-x-3 sm:gap-x-6">
-					{/* Network Switcher */}
+					{/* Network Switcher — global testnet/mainnet toggle, persisted via NetworkContext */}
 					<div
 						role="group"
 						aria-label="Network selector"
-						className="flex items-center rounded-lg border border-gray-200 bg-gray-50 p-0.5 text-sm font-medium"
+						className="flex shrink-0 items-center rounded-lg border border-gray-200 bg-gray-50 p-0.5 text-xs font-medium dark:border-zinc-700 dark:bg-zinc-800 sm:text-sm"
 					>
 						<button
 							type="button"
 							onClick={() => setNetwork("testnet")}
 							aria-pressed={network === "testnet"}
 							aria-label="Switch to Testnet"
-							className={`rounded-md px-3 py-1 transition-colors ${
+							className={`rounded-md px-2 py-1 transition-colors sm:px-3 ${
 								network === "testnet"
 									? "bg-amber-100 text-amber-900"
-									: "text-gray-500 hover:text-gray-700"
+									: "text-gray-500 hover:text-gray-700 dark:text-zinc-400 dark:hover:text-zinc-200"
 							}`}
 						>
 							Testnet
@@ -132,10 +132,10 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 							onClick={() => setNetwork("mainnet")}
 							aria-pressed={network === "mainnet"}
 							aria-label="Switch to Mainnet"
-							className={`rounded-md px-3 py-1 transition-colors ${
+							className={`rounded-md px-2 py-1 transition-colors sm:px-3 ${
 								network === "mainnet"
 									? "bg-blue-100 text-blue-900"
-									: "text-gray-500 hover:text-gray-700"
+									: "text-gray-500 hover:text-gray-700 dark:text-zinc-400 dark:hover:text-zinc-200"
 							}`}
 						>
 							Mainnet

--- a/src/components/wallet/WalletDetail.tsx
+++ b/src/components/wallet/WalletDetail.tsx
@@ -5,6 +5,7 @@ import { useCallback, useId } from "react";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { ErrorState } from "@/components/ui/ErrorState";
+import { ExplorerLink } from "@/components/ui/ExplorerLink";
 import { Skeleton, WalletDetailSkeleton } from "@/components/ui/Skeleton";
 import { NetworkBadge } from "@/components/wallet/NetworkBadge";
 import { StatusIndicator } from "@/components/wallet/StatusIndicator";
@@ -186,6 +187,14 @@ export function WalletDetail({ id }: WalletDetailProps) {
 										{copyError}
 									</p>
 								)}
+								<ExplorerLink
+									address={wallet.address}
+									network={wallet.network}
+									type="account"
+									size="icon-sm"
+									showIcon
+									title="View on Stellar Explorer"
+								/>
 							</dd>
 						</div>
 						<div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">

--- a/src/test/network.test.tsx
+++ b/src/test/network.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { WalletTable } from "@/components/wallet/WalletTable";
 import { NetworkProvider, useNetwork } from "@/context/NetworkContext";
 import type { Wallet } from "@/types/wallet";
@@ -55,6 +55,54 @@ describe("NetworkContext", () => {
 			"useNetwork must be used within NetworkProvider",
 		);
 		console.error = original;
+	});
+});
+
+describe("NetworkContext — localStorage persistence", () => {
+	beforeEach(() => {
+		localStorage.removeItem("mux_network");
+	});
+
+	afterEach(() => {
+		localStorage.removeItem("mux_network");
+	});
+
+	it("persists the selected network to localStorage", () => {
+		render(
+			<NetworkProvider>
+				<NetworkDisplay />
+			</NetworkProvider>,
+		);
+		fireEvent.click(screen.getByText("Switch Testnet"));
+		expect(localStorage.getItem("mux_network")).toBe("testnet");
+	});
+
+	it("restores the persisted network after a remount (e.g. page reload)", () => {
+		const { unmount } = render(
+			<NetworkProvider>
+				<NetworkDisplay />
+			</NetworkProvider>,
+		);
+		fireEvent.click(screen.getByText("Switch Testnet"));
+		expect(screen.getByTestId("network")).toHaveTextContent("testnet");
+		unmount();
+
+		render(
+			<NetworkProvider>
+				<NetworkDisplay />
+			</NetworkProvider>,
+		);
+		expect(screen.getByTestId("network")).toHaveTextContent("testnet");
+	});
+
+	it("falls back to the default network when localStorage holds an invalid value", () => {
+		localStorage.setItem("mux_network", "not-a-real-network");
+		render(
+			<NetworkProvider>
+				<NetworkDisplay />
+			</NetworkProvider>,
+		);
+		expect(screen.getByTestId("network")).toHaveTextContent("mainnet");
 	});
 });
 


### PR DESCRIPTION
Closes #422
Closes #424
Closes #425
Closes #427

## Summary

**#422 — Show error state with retry on wallets fetch failure**
`/dashboard/wallets` previously rendered static mock data with no real fetch, loading, or error handling. It now uses the existing `useWallets()` hook so it performs a real fetch, with three clearly distinct states: a `WalletTableSkeleton` while loading, an `ErrorState` with a "Retry" button (calls `useWallets().refetch`) when the request fails, and the existing `EmptyState` only once the fetch succeeds with zero wallets. Updated `page.test.tsx` to mock `fetch` and added coverage for the error/retry path.

**#424 — Persist selected network in local storage**
`NetworkContext` already persisted the selected testnet/mainnet choice to `localStorage`, with an SSR-safe read and a `mainnet` fallback when nothing is stored or the value is invalid. Added explicit test coverage (`src/test/network.test.tsx`) verifying the value is written on change and restored after a remount (i.e. surviving a page reload), plus a case for the invalid-value fallback.

**#425 — Add global testnet/mainnet toggle in shell**
The `TopNav` shell already exposed a global network switcher wired to `NetworkContext` (and therefore persisted per #424) across all dashboard pages. Polished it for narrow mobile viewports (tighter padding/type scale below `sm`) and added dark-mode styling for the inactive button state so it stays legible in both themes.

**#427 — Add explorer link for wallet addresses**
`WalletTable` already linked each row's address to Stellar Expert via the existing `ExplorerLink` component + `explorerUrl` helper (network-aware: testnet addresses → testnet explorer, mainnet → public explorer). Wired the same `ExplorerLink` into the two places that were missing it: `WalletDetail` (the wallet detail route) and the standalone `/wallet` page, next to the existing copy-address button.

## Test plan
- [ ] `/dashboard/wallets` shows a skeleton, then table/empty/error state correctly depending on the API response; Retry re-fetches
- [ ] Switching network in the top nav updates the badge/title and persists across a reload
- [ ] Wallet detail and `/wallet` pages show a working "View on Stellar Explorer" link next to the address