### PR TITLE
Per-wallet Friendbot hint on testnet, address display consistency (#426, #428, #429, #430)

### DIFF
--- a/src/components/ui/TestnetHint.tsx
+++ b/src/components/ui/TestnetHint.tsx
@@ -1,15 +1,26 @@
 "use client";
 
 import { AlertCircle, ExternalLink, X } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { FRIENDBOT_DOCS_URL, FRIENDBOT_URL } from "@/utils/friendbot";
+import {
+	FRIENDBOT_DOCS_URL,
+	FRIENDBOT_URL,
+	getFriendbotUrl,
+	isValidAddressForFriendbot,
+} from "@/utils/friendbot";
 
 interface TestnetHintProps {
 	variant?: "default" | "compact";
 	dismissible?: boolean;
 	className?: string;
+	/**
+	 * Optional wallet address to fund directly. When provided (and valid),
+	 * the "Fund via Friendbot" link pre-fills that address instead of
+	 * linking to the generic Friendbot landing page.
+	 */
+	address?: string;
 }
 
 /**
@@ -20,17 +31,27 @@ interface TestnetHintProps {
  * - Shows only on testnet (parent component responsible for conditional rendering)
  * - Dismissible state is local to component (not persisted)
  * - Provides links to Friendbot and documentation
+ * - When `address` is a valid Stellar address, the Friendbot link funds that
+ *   address directly instead of pointing at the generic landing page
  */
 export function TestnetHint({
 	variant = "default",
 	dismissible = true,
 	className,
+	address,
 }: TestnetHintProps) {
 	const [isDismissed, setIsDismissed] = useState(false);
 
 	const handleDismiss = useCallback(() => {
 		setIsDismissed(true);
 	}, []);
+
+	const friendbotUrl = useMemo(() => {
+		if (address && isValidAddressForFriendbot(address)) {
+			return getFriendbotUrl(address);
+		}
+		return FRIENDBOT_URL;
+	}, [address]);
 
 	if (isDismissed) {
 		return null;
@@ -48,12 +69,14 @@ export function TestnetHint({
 				<p className="text-xs text-amber-700 dark:text-amber-300">
 					You&apos;re on testnet.{" "}
 					<a
-						href={FRIENDBOT_URL}
+						href={friendbotUrl}
 						target="_blank"
 						rel="noopener noreferrer"
 						className="underline hover:no-underline font-medium"
 					>
-						Fund with Friendbot
+						{address
+							? "Fund this wallet with Friendbot"
+							: "Fund with Friendbot"}
 					</a>
 				</p>
 				{dismissible && (
@@ -90,20 +113,22 @@ export function TestnetHint({
 					<p className="text-sm text-amber-800 dark:text-amber-200">
 						This is a test network for development and testing. Use{" "}
 						<a
-							href={FRIENDBOT_URL}
+							href={friendbotUrl}
 							target="_blank"
 							rel="noopener noreferrer"
 							className="font-medium underline hover:no-underline"
 						>
 							Friendbot
 						</a>{" "}
-						to fund new accounts with test XLM.
+						{address
+							? "to fund this wallet with test XLM."
+							: "to fund new accounts with test XLM."}
 					</p>
 					<div className="flex flex-wrap gap-2 pt-2">
 						<Button variant="outline" size="sm" asChild className="h-8 text-xs">
-							<a href={FRIENDBOT_URL} target="_blank" rel="noopener noreferrer">
+							<a href={friendbotUrl} target="_blank" rel="noopener noreferrer">
 								<ExternalLink className="h-3 w-3" />
-								Open Friendbot
+								{address ? "Fund via Friendbot" : "Open Friendbot"}
 							</a>
 						</Button>
 						<Button variant="outline" size="sm" asChild className="h-8 text-xs">

--- a/src/components/wallet/AddWalletModal.tsx
+++ b/src/components/wallet/AddWalletModal.tsx
@@ -1,10 +1,23 @@
 "use client";
 
-import { AlertCircle, CheckCircle2, Loader2, Plus, X } from "lucide-react";
+import {
+	AlertCircle,
+	Check,
+	CheckCircle2,
+	Copy,
+	Loader2,
+	Plus,
+	X,
+} from "lucide-react";
 import { useEffect, useId, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { TestnetHint } from "@/components/ui/TestnetHint";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import type { Wallet, WalletNetwork } from "@/types/wallet";
-import { validateStellarAddress } from "@/utils/addressFormatting";
+import {
+	truncateAddress,
+	validateStellarAddress,
+} from "@/utils/addressFormatting";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -75,6 +88,7 @@ export function AddWalletModal({
 	const [addressError, setAddressError] = useState<string | undefined>();
 	const [labelError, setLabelError] = useState<string | undefined>();
 	const [addedWallet, setAddedWallet] = useState<Wallet | null>(null);
+	const { copy, copied, error: copyError } = useCopyToClipboard();
 
 	const addressInputRef = useRef<HTMLInputElement>(null);
 	const closeButtonRef = useRef<HTMLButtonElement>(null);
@@ -407,6 +421,14 @@ export function AddWalletModal({
 								</div>
 							</div>
 
+							{addedWallet.network === "testnet" && (
+								<TestnetHint
+									variant="compact"
+									dismissible={false}
+									address={addedWallet.address}
+								/>
+							)}
+
 							<div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800">
 								<dl className="space-y-2 text-sm">
 									{addedWallet.label && (
@@ -419,13 +441,46 @@ export function AddWalletModal({
 											</dd>
 										</div>
 									)}
-									<div className="flex justify-between gap-4">
+									<div className="flex items-center justify-between gap-4">
 										<dt className="text-zinc-500 dark:text-zinc-400">
 											Address
 										</dt>
-										<dd className="truncate font-mono text-zinc-900 dark:text-zinc-50">
-											{addedWallet.address.slice(0, 8)}…
-											{addedWallet.address.slice(-6)}
+										<dd className="flex items-center gap-1 font-mono text-zinc-900 dark:text-zinc-50">
+											<span className="truncate">
+												{truncateAddress(addedWallet.address)}
+											</span>
+											<Button
+												variant="ghost"
+												size="icon-sm"
+												onClick={() =>
+													copy(addedWallet.address, addedWallet.address)
+												}
+												disabled={!!copyError}
+												aria-label={
+													copyError
+														? copyError
+														: copied
+															? "Address copied"
+															: "Copy wallet address"
+												}
+												title={
+													copyError ? copyError : copied ? "Copied!" : "Copy address"
+												}
+											>
+												{copyError ? (
+													<AlertCircle
+														className="h-4 w-4 text-red-500"
+														aria-hidden="true"
+													/>
+												) : copied ? (
+													<Check
+														className="h-4 w-4 text-green-500"
+														aria-hidden="true"
+													/>
+												) : (
+													<Copy className="h-4 w-4" aria-hidden="true" />
+												)}
+											</Button>
 										</dd>
 									</div>
 									<div className="flex justify-between gap-4">

--- a/src/components/wallet/WalletDetail.tsx
+++ b/src/components/wallet/WalletDetail.tsx
@@ -7,6 +7,7 @@ import { EmptyState } from "@/components/ui/EmptyState";
 import { ErrorState } from "@/components/ui/ErrorState";
 import { ExplorerLink } from "@/components/ui/ExplorerLink";
 import { Skeleton, WalletDetailSkeleton } from "@/components/ui/Skeleton";
+import { TestnetHint } from "@/components/ui/TestnetHint";
 import { NetworkBadge } from "@/components/wallet/NetworkBadge";
 import { StatusIndicator } from "@/components/wallet/StatusIndicator";
 import { useAnalyticsTracking } from "@/hooks/useAnalyticsTracking";
@@ -77,6 +78,14 @@ export function WalletDetail({ id }: WalletDetailProps) {
 
 	return (
 		<div className="space-y-4 sm:space-y-6">
+			{wallet?.network === "testnet" && (
+				<TestnetHint
+					variant="compact"
+					dismissible={false}
+					address={wallet.address}
+				/>
+			)}
+
 			{/* Balance card */}
 			<section
 				aria-labelledby={balanceHeadingId}


### PR DESCRIPTION
Closes #426
Closes #428
Closes #429
Closes #430

## Context

While investigating these four issues I found that most of the underlying functionality already exists in `WalletTable` / `WalletDetail`, added by prior work (network context, `useWallets`, explorer links, etc.):

- **#426 (network badge per row):** `NetworkBadge` is already rendered per wallet row in both the desktop table and mobile card views of `WalletTable`, sourced from the wallet's own `network` field.
- **#428 (truncate + copy addresses):** `truncateAddress()` (`src/utils/addressFormatting.ts`) and the `useCopyToClipboard` hook already truncate for display and copy the full untruncated address, used in both `WalletTable` and `WalletDetail`.
- **#429 (validate before copy feedback):** `useCopyToClipboard` already validates via `isSafeToCopy`/`getAddressToCopy` (`src/utils/addressValidation.ts`) before flipping to the "Copied!" state, showing an error icon and disabling the button on invalid input instead.

So the remaining gap was **#430**: `WalletDetail` had no testnet/Friendbot hint at all (unlike `WalletTable`, which shows one), and the existing `getFriendbotUrl(address)` helper (`src/utils/friendbot.ts`) was defined but never wired into any UI — the existing `TestnetHint` component only ever linked to the generic Friendbot landing page.

## Changes

- **`src/components/ui/TestnetHint.tsx`** — added an optional `address` prop. When a valid Stellar address is passed, the Friendbot link/button uses `getFriendbotUrl(address)` to fund that specific wallet directly, with copy adjusted to "Fund this wallet with Friendbot" / "Fund via Friendbot". Falls back to the generic Friendbot URL/copy when no address is given, so existing call sites and tests are unaffected.
- **`src/components/wallet/WalletDetail.tsx`** — now renders a compact `TestnetHint` (wired to the viewed wallet's address) whenever `wallet.network === "testnet"`, matching the hint already shown in `WalletTable`. Never shows on mainnet.
- **`src/components/wallet/AddWalletModal.tsx`** — the "wallet added" success screen:
  - now shows the same testnet Friendbot hint for freshly-added testnet wallets (the moment a user most likely wants to fund a brand-new test wallet), and
  - the address preview now uses the shared `truncateAddress()` util plus a copy-to-clipboard button (same icon/validation/error pattern as `WalletTable`/`WalletDetail`) instead of an ad-hoc `slice()` display with no copy affordance — for consistency across all the places addresses are shown, per #428/#429.

## Notes

No test suite / build / lint was run as part of this change per the task instructions; existing `TestnetHint` tests don't pass an `address` prop so they continue to exercise the original generic-link behavior unchanged.