### PR TITLE
feat: improve Stellar wallet, network, and profile settings flows

### DIFF
--- a/src/app/api/wallets/[id]/route.test.ts
+++ b/src/app/api/wallets/[id]/route.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { GET } from "./route";
+import { GET, PATCH } from "./route";
 
 describe("/api/wallets/[id]", () => {
 	it("returns a wallet when the id exists", async () => {
@@ -35,5 +35,28 @@ describe("/api/wallets/[id]", () => {
 
 		expect(response.status).toBe(404);
 		await expect(response.json()).resolves.toEqual({ error: "not_found" });
+	});
+
+	it("updates a wallet nickname", async () => {
+		const response = await PATCH(
+			new Request("http://localhost/api/wallets/wallet-001", {
+				method: "PATCH",
+				body: JSON.stringify({ label: "Treasury" }),
+			}),
+			{ params: { id: "wallet-001" } },
+		);
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toMatchObject({ label: "Treasury" });
+	});
+
+	it("rejects an invalid wallet nickname", async () => {
+		const response = await PATCH(
+			new Request("http://localhost/api/wallets/wallet-001", {
+				method: "PATCH",
+				body: JSON.stringify({ label: "<script>" }),
+			}),
+			{ params: { id: "wallet-001" } },
+		);
+		expect(response.status).toBe(422);
 	});
 });

--- a/src/app/api/wallets/[id]/route.ts
+++ b/src/app/api/wallets/[id]/route.ts
@@ -22,3 +22,34 @@ export async function GET(_request: Request, { params }: RouteContext) {
 
 	return NextResponse.json(wallet);
 }
+
+export async function PATCH(request: Request, { params }: RouteContext) {
+	const { id } = await params;
+	const wallet = dummyWallets.find((candidate) => candidate.id === id.trim());
+	if (!wallet) {
+		return NextResponse.json({ error: "not_found" }, { status: 404 });
+	}
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+	}
+
+	const label =
+		typeof body === "object" && body !== null && "label" in body
+			? (body as { label: unknown }).label
+			: undefined;
+	if (typeof label !== "string") {
+		return NextResponse.json({ error: "label_required" }, { status: 400 });
+	}
+
+	const normalized = label.trim();
+	if (normalized.length > 30 || /[<>"'&]/.test(normalized)) {
+		return NextResponse.json({ error: "invalid_label" }, { status: 422 });
+	}
+
+	wallet.label = normalized || undefined;
+	return NextResponse.json(wallet);
+}

--- a/src/app/dashboard/settings/page.test.tsx
+++ b/src/app/dashboard/settings/page.test.tsx
@@ -1,0 +1,23 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SettingsPage from "./page";
+
+vi.mock("@/context/AuthContext", () => ({
+	useAuth: () => ({
+		user: { name: "Mux Developer", email: "dev@example.com", role: "developer" },
+		isLoading: false,
+	}),
+}));
+
+describe("SettingsPage", () => {
+	beforeEach(() => localStorage.clear());
+
+	it("renders and persists profile preferences", () => {
+		render(<SettingsPage />);
+		const input = screen.getByLabelText("Display name");
+		fireEvent.change(input, { target: { value: "Stellar Builder" } });
+		fireEvent.click(screen.getByRole("button", { name: "Save preferences" }));
+		expect(screen.getByText("Saved")).toBeInTheDocument();
+		expect(localStorage.getItem("mux_profile_preferences")).toContain("Stellar Builder");
+	});
+});

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { Check, Loader2, UserRound } from "lucide-react";
+import { useEffect, useState } from "react";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/context/AuthContext";
+
+const PREFERENCES_KEY = "mux_profile_preferences";
+
+type Preferences = {
+	displayName: string;
+	emailUpdates: boolean;
+	compactWallets: boolean;
+};
+
+export default function SettingsPage() {
+	const { user, isLoading } = useAuth();
+	const [preferences, setPreferences] = useState<Preferences>({
+		displayName: "",
+		emailUpdates: true,
+		compactWallets: false,
+	});
+	const [saved, setSaved] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (!user) return;
+		try {
+			const stored = localStorage.getItem(PREFERENCES_KEY);
+			const storedPreferences = stored
+				? (JSON.parse(stored) as Partial<Preferences>)
+				: null;
+			setPreferences(
+				storedPreferences
+					? {
+							displayName: storedPreferences.displayName || user.name,
+							emailUpdates: storedPreferences.emailUpdates ?? true,
+							compactWallets: storedPreferences.compactWallets ?? false,
+						}
+					: { displayName: user.name, emailUpdates: true, compactWallets: false },
+			);
+		} catch {
+			setPreferences({
+				displayName: user.name,
+				emailUpdates: true,
+				compactWallets: false,
+			});
+			setError("Saved preferences could not be loaded. You can replace them below.");
+		}
+	}, [user]);
+
+	function savePreferences(event: React.FormEvent) {
+		event.preventDefault();
+		setError(null);
+		if (!preferences.displayName.trim()) {
+			setError("Display name is required.");
+			return;
+		}
+		try {
+			localStorage.setItem(
+				PREFERENCES_KEY,
+				JSON.stringify({
+					...preferences,
+					displayName: preferences.displayName.trim(),
+				}),
+			);
+			setSaved(true);
+			window.setTimeout(() => setSaved(false), 2500);
+		} catch {
+			setError("Preferences could not be saved in this browser.");
+		}
+	}
+
+	if (isLoading) {
+		return (
+			<div role="status" className="flex min-h-64 items-center justify-center gap-2 text-zinc-500">
+				<Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" />
+				Loading profile preferences…
+			</div>
+		);
+	}
+
+	if (!user) {
+		return (
+			<EmptyState
+				title="Profile unavailable"
+				description="Sign in to view and update your profile preferences."
+			/>
+		);
+	}
+
+	return (
+		<div className="space-y-8">
+			<PageHeader
+				title="Settings"
+				description="Manage your profile and developer console preferences."
+			/>
+			<div className="grid gap-6 lg:grid-cols-[220px_minmax(0,1fr)]">
+				<nav aria-label="Settings sections" className="h-fit rounded-xl border border-zinc-200 bg-white p-2 dark:border-zinc-800 dark:bg-zinc-900">
+					<a
+						href="#profile"
+						aria-current="page"
+						className="flex items-center gap-2 rounded-lg bg-blue-50 px-3 py-2 text-sm font-medium text-blue-700 dark:bg-blue-950/40 dark:text-blue-300"
+					>
+						<UserRound className="h-4 w-4" aria-hidden="true" />
+						Profile preferences
+					</a>
+				</nav>
+				<form
+					id="profile"
+					onSubmit={savePreferences}
+					className="rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900"
+				>
+					<div className="border-b border-zinc-200 p-5 sm:p-6 dark:border-zinc-800">
+						<h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+							Profile preferences
+						</h2>
+						<p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+							Personalize how the console presents your account and wallet data.
+						</p>
+					</div>
+					<div className="space-y-6 p-5 sm:p-6">
+						<div>
+							<label htmlFor="display-name" className="block text-sm font-medium text-zinc-800 dark:text-zinc-200">
+								Display name
+							</label>
+							<input
+								id="display-name"
+								value={preferences.displayName}
+								onChange={(event) =>
+									setPreferences((current) => ({ ...current, displayName: event.target.value }))
+								}
+								className="mt-2 w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-zinc-900 sm:max-w-md dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-50"
+							/>
+							<p className="mt-1 text-xs text-zinc-500">Signed in as {user.email}</p>
+						</div>
+						{([
+							["emailUpdates", "Product email updates", "Receive occasional platform and security announcements."],
+							["compactWallets", "Compact wallet rows", "Show more wallets at once on narrow screens."],
+						] as const).map(([key, label, description]) => (
+							<label key={key} className="flex items-start gap-3">
+								<input
+									type="checkbox"
+									checked={preferences[key]}
+									onChange={(event) =>
+										setPreferences((current) => ({ ...current, [key]: event.target.checked }))
+									}
+									className="mt-1 h-4 w-4 rounded border-zinc-300"
+								/>
+								<span>
+									<span className="block text-sm font-medium text-zinc-800 dark:text-zinc-200">{label}</span>
+									<span className="block text-sm text-zinc-500 dark:text-zinc-400">{description}</span>
+								</span>
+							</label>
+						))}
+						{error && <p role="alert" className="text-sm text-red-600 dark:text-red-400">{error}</p>}
+					</div>
+					<div className="flex items-center justify-end gap-3 border-t border-zinc-200 p-4 sm:px-6 dark:border-zinc-800">
+						{saved && <span role="status" className="flex items-center gap-1 text-sm text-green-700 dark:text-green-400"><Check className="h-4 w-4" /> Saved</span>}
+						<Button type="submit">Save preferences</Button>
+					</div>
+				</form>
+			</div>
+		</div>
+	);
+}

--- a/src/app/dashboard/wallets/[id]/page.tsx
+++ b/src/app/dashboard/wallets/[id]/page.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+import { WalletDetail } from "@/components/wallet/WalletDetail";
+
+export default async function WalletDetailPage({
+	params,
+}: {
+	params: Promise<{ id: string }>;
+}) {
+	const { id } = await params;
+	return (
+		<div className="space-y-6">
+			<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+				<div>
+					<h2 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">
+						Wallet Detail
+					</h2>
+					<p className="text-sm text-zinc-500 dark:text-zinc-400">
+						Live balance, identity, and account activity
+					</p>
+				</div>
+				<Link
+					href="/dashboard/wallets"
+					className="text-sm font-medium text-blue-700 hover:underline dark:text-blue-400"
+				>
+					← Back to wallets
+				</Link>
+			</div>
+			<WalletDetail id={id} />
+		</div>
+	);
+}

--- a/src/components/layouts/Sidebar.tsx
+++ b/src/components/layouts/Sidebar.tsx
@@ -33,7 +33,7 @@ function isNavItemActive(pathname: string, itemHref: string): boolean {
 	// Exact match
 	if (pathname === itemHref) return true;
 	// For the Dashboard root item, only match exact
-	if (itemHref === "/demo/dashboard") return false;
+	if (itemHref === "/dashboard") return false;
 	// For other items, match if the pathname starts with the item's href
 	// (handles nested routes like /demo/dashboard/settings/profile)
 	return pathname.startsWith(itemHref + "/") || pathname.startsWith(itemHref);

--- a/src/components/layouts/TopNav.tsx
+++ b/src/components/layouts/TopNav.tsx
@@ -34,7 +34,11 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 
 	// Get current page title from pathname
 	const pageTitle = (() => {
-		const segment = pathname.split("/").pop() ?? "";
+		const segments = pathname.split("/").filter(Boolean);
+		const segment = segments.at(-1) ?? "";
+		if (segments.at(-2) === "wallets" && segment !== "wallets") {
+			return "Wallet Detail";
+		}
 		const titleMap: Record<string, string> = {
 			dashboard: "Dashboard",
 			analytics: "Analytics",
@@ -50,11 +54,6 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 		);
 	})();
 
-	useEffect(() => {
-		document.title = `${pageTitle} · ${networkLabel[network]} — Mux`;
-	}, [pageTitle, network]);
-
-	// Sync browser tab title
 	useEffect(() => {
 		document.title = `${pageTitle} · ${networkLabel[network]} — Mux`;
 	}, [pageTitle, network]);

--- a/src/components/wallet/AddWalletModal.test.tsx
+++ b/src/components/wallet/AddWalletModal.test.tsx
@@ -68,6 +68,23 @@ describe("AddWalletModal form", () => {
 // ─── Address validation ───────────────────────────────────────────────────────
 
 describe("AddWalletModal address validation", () => {
+	it("shows a client-side checksum hint for a valid address", async () => {
+		const user = userEvent.setup();
+		renderModal();
+		await user.type(screen.getByLabelText(/stellar address/i), VALID_ADDRESS);
+		expect(screen.getByText(/checksum verified/i)).toBeInTheDocument();
+	});
+
+	it("warns when a complete address has a mismatched checksum", async () => {
+		const user = userEvent.setup();
+		renderModal();
+		await user.type(
+			screen.getByLabelText(/stellar address/i),
+			`${VALID_ADDRESS.slice(0, -1)}A`,
+		);
+		expect(screen.getByText(/checksum does not match/i)).toBeInTheDocument();
+	});
+
 	it("shows an error when submitting an empty address", async () => {
 		const user = userEvent.setup();
 		renderModal();

--- a/src/components/wallet/AddWalletModal.tsx
+++ b/src/components/wallet/AddWalletModal.tsx
@@ -18,6 +18,7 @@ import {
 	truncateAddress,
 	validateStellarAddress,
 } from "@/utils/addressFormatting";
+import { hasValidStellarChecksum } from "@/utils/addressValidation";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -205,6 +206,12 @@ export function AddWalletModal({
 	if (!isOpen) return null;
 
 	const charCount = address.trim().length;
+	const checksumState =
+		charCount === 56
+			? hasValidStellarChecksum(address)
+				? "valid"
+				: "invalid"
+			: "pending";
 
 	return (
 		<div
@@ -273,7 +280,9 @@ export function AddWalletModal({
 										autoComplete="off"
 										spellCheck={false}
 										aria-describedby={
-											addressError ? `${addressId}-error` : undefined
+											addressError
+												? `${addressId}-error ${addressId}-checksum`
+												: `${addressId}-checksum`
 										}
 										aria-invalid={!!addressError}
 										className={`
@@ -295,8 +304,22 @@ export function AddWalletModal({
 										</span>
 									)}
 									<div className="mt-1.5 flex items-center justify-between">
-										<p className="text-xs text-zinc-500 dark:text-zinc-400">
-											56-character Stellar public key starting with G.
+										<p
+											id={`${addressId}-checksum`}
+											aria-live="polite"
+											className={`text-xs ${
+												checksumState === "valid"
+													? "text-green-700 dark:text-green-400"
+													: checksumState === "invalid"
+														? "text-red-600 dark:text-red-400"
+														: "text-zinc-500 dark:text-zinc-400"
+											}`}
+										>
+											{checksumState === "valid"
+												? "Checksum verified — this is a valid Stellar account."
+												: checksumState === "invalid"
+													? "Checksum does not match. Check the final characters."
+													: "56-character Stellar public key starting with G; checksum is verified locally."}
 										</p>
 										{charCount > 0 && (
 											<span

--- a/src/components/wallet/WalletDetail.test.tsx
+++ b/src/components/wallet/WalletDetail.test.tsx
@@ -101,4 +101,22 @@ describe("WalletDetail", () => {
 			screen.getByRole("button", { name: /refresh balance/i }),
 		).toBeDisabled();
 	});
+
+	it("edits and saves the wallet nickname from detail", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+		);
+		render(<WalletDetail id="wallet-001" />);
+		fireEvent.click(screen.getByRole("button", { name: "Edit wallet nickname" }));
+		fireEvent.change(screen.getByLabelText("Wallet nickname"), {
+			target: { value: "Treasury" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Save nickname" }));
+		await waitFor(() => expect(screen.getByText("Treasury")).toBeInTheDocument());
+		expect(fetch).toHaveBeenCalledWith(
+			"/api/wallets/wallet-001",
+			expect.objectContaining({ method: "PATCH" }),
+		);
+	});
 });

--- a/src/components/wallet/WalletDetail.tsx
+++ b/src/components/wallet/WalletDetail.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { AlertCircle, Check, Copy, RefreshCw } from "lucide-react";
-import { useCallback, useId, useState } from "react";
+import { AlertCircle, Check, Copy, Pencil, RefreshCw, X } from "lucide-react";
+import { useCallback, useEffect, useId, useState } from "react";
 import TransactionsTable from "@/components/TransactionsTable/TransactionsTable";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -39,6 +39,18 @@ export function WalletDetail({ id }: WalletDetailProps) {
 	const infoHeadingId = useId();
 	const [isSendOpen, setIsSendOpen] = useState(false);
 	const [isReceiveOpen, setIsReceiveOpen] = useState(false);
+	const [isEditingNickname, setIsEditingNickname] = useState(false);
+	const [nickname, setNickname] = useState("");
+	const [savedNickname, setSavedNickname] = useState("");
+	const [nicknameStatus, setNicknameStatus] = useState<
+		"idle" | "saving" | "error"
+	>("idle");
+
+	useEffect(() => {
+		const nextNickname = wallet?.label ?? "";
+		setNickname(nextNickname);
+		setSavedNickname(nextNickname);
+	}, [wallet?.label]);
 
 	const canReceive = !!wallet && isValidStellarAddress(wallet.address.trim());
 	const canSend = isWalletFunded(wallet);
@@ -61,6 +73,30 @@ export function WalletDetail({ id }: WalletDetailProps) {
 		},
 		[id, track, copy],
 	);
+
+	async function saveNickname(event: React.FormEvent) {
+		event.preventDefault();
+		const normalized = nickname.trim();
+		if (normalized.length > 30 || /[<>"'&]/.test(normalized)) {
+			setNicknameStatus("error");
+			return;
+		}
+		setNicknameStatus("saving");
+		try {
+			const response = await fetch(`/api/wallets/${encodeURIComponent(id)}`, {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ label: normalized }),
+			});
+			if (!response.ok) throw new Error("Unable to save nickname");
+			setSavedNickname(normalized);
+			setNickname(normalized);
+			setIsEditingNickname(false);
+			setNicknameStatus("idle");
+		} catch {
+			setNicknameStatus("error");
+		}
+	}
 
 	if (error && !wallet) {
 		return (
@@ -152,7 +188,7 @@ export function WalletDetail({ id }: WalletDetailProps) {
 						{error}
 					</p>
 				)}
-			</div>
+			</section>
 
 			{/* Wallet metadata */}
 			{wallet ? (
@@ -167,6 +203,69 @@ export function WalletDetail({ id }: WalletDetailProps) {
 						Wallet Info
 					</h2>
 					<dl className="space-y-4">
+						<div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
+							<dt className="pt-2 text-sm text-zinc-500 dark:text-zinc-400">
+								Nickname
+							</dt>
+							<dd className="w-full sm:max-w-xs">
+								{isEditingNickname ? (
+									<form onSubmit={saveNickname} className="space-y-1.5">
+										<div className="flex gap-2">
+											<label htmlFor={`${id}-nickname`} className="sr-only">
+												Wallet nickname
+											</label>
+											<input
+												id={`${id}-nickname`}
+												value={nickname}
+												onChange={(event) => {
+													setNickname(event.target.value);
+													setNicknameStatus("idle");
+												}}
+												maxLength={30}
+												autoFocus
+												placeholder="Add a nickname"
+												className="min-w-0 flex-1 rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-50"
+											/>
+											<Button size="icon-sm" type="submit" disabled={nicknameStatus === "saving"} aria-label="Save nickname">
+												<Check aria-hidden="true" />
+											</Button>
+											<Button
+												size="icon-sm"
+												variant="ghost"
+												type="button"
+												aria-label="Cancel nickname edit"
+												onClick={() => {
+													setNickname(savedNickname);
+													setNicknameStatus("idle");
+													setIsEditingNickname(false);
+												}}
+											>
+												<X aria-hidden="true" />
+											</Button>
+										</div>
+										{nicknameStatus === "error" && (
+											<p role="alert" className="text-xs text-red-600 dark:text-red-400">
+												Nickname could not be saved. Use at most 30 characters and try again.
+											</p>
+										)}
+									</form>
+								) : (
+									<div className="flex items-center justify-end gap-2">
+										<span className="text-sm text-zinc-700 dark:text-zinc-300">
+											{savedNickname || "No nickname"}
+										</span>
+										<Button
+											size="icon-sm"
+											variant="ghost"
+											aria-label="Edit wallet nickname"
+											onClick={() => setIsEditingNickname(true)}
+										>
+											<Pencil aria-hidden="true" />
+										</Button>
+									</div>
+								)}
+							</dd>
+						</div>
 						<div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
 							<dt className="text-sm text-zinc-500 dark:text-zinc-400">
 								Address
@@ -253,7 +352,7 @@ export function WalletDetail({ id }: WalletDetailProps) {
 							</div>
 						)}
 					</dl>
-				</div>
+				</section>
 			) : (
 				<div className="rounded-xl border border-zinc-200 bg-white p-4 sm:p-6 dark:border-zinc-800 dark:bg-zinc-900">
 					<Skeleton className="mb-4 h-4 w-24" />

--- a/src/components/wallet/WalletTable.tsx
+++ b/src/components/wallet/WalletTable.tsx
@@ -146,7 +146,7 @@ export function WalletTable({
 				case "Enter":
 				case " ":
 					event.preventDefault();
-					router.push(`/demo/dashboard/wallets/${wallets[index].id}`);
+					router.push(`/dashboard/wallets/${wallets[index].id}`);
 					break;
 				case "Home":
 					event.preventDefault();
@@ -239,7 +239,7 @@ export function WalletTable({
 										>
 											<TableCell>
 												<Link
-													href={`/demo/dashboard/wallets/${wallet.id}`}
+													href={`/dashboard/wallets/${wallet.id}`}
 													className="block"
 													tabIndex={-1}
 												>
@@ -253,7 +253,7 @@ export function WalletTable({
 											</TableCell>
 											<TableCell>
 												<Link
-													href={`/demo/dashboard/wallets/${wallet.id}`}
+													href={`/dashboard/wallets/${wallet.id}`}
 													className="block"
 													tabIndex={-1}
 												>
@@ -262,7 +262,7 @@ export function WalletTable({
 											</TableCell>
 											<TableCell>
 												<Link
-													href={`/demo/dashboard/wallets/${wallet.id}`}
+													href={`/dashboard/wallets/${wallet.id}`}
 													className="block"
 													tabIndex={-1}
 												>
@@ -271,7 +271,7 @@ export function WalletTable({
 											</TableCell>
 											<TableCell>
 												<Link
-													href={`/demo/dashboard/wallets/${wallet.id}`}
+													href={`/dashboard/wallets/${wallet.id}`}
 													className="block text-zinc-700 dark:text-zinc-300"
 													tabIndex={-1}
 												>
@@ -280,7 +280,7 @@ export function WalletTable({
 											</TableCell>
 											<TableCell className="text-zinc-500 dark:text-zinc-400">
 												<Link
-													href={`/demo/dashboard/wallets/${wallet.id}`}
+													href={`/dashboard/wallets/${wallet.id}`}
 													className="block"
 													tabIndex={-1}
 												>
@@ -289,7 +289,7 @@ export function WalletTable({
 											</TableCell>
 											<TableCell className="text-zinc-500 dark:text-zinc-400">
 												<Link
-													href={`/demo/dashboard/wallets/${wallet.id}`}
+													href={`/dashboard/wallets/${wallet.id}`}
 													className="block"
 													tabIndex={-1}
 												>
@@ -307,7 +307,7 @@ export function WalletTable({
 							{wallets.map((wallet) => (
 								<Link
 									key={wallet.id}
-									href={`/demo/dashboard/wallets/${wallet.id}`}
+									href={`/dashboard/wallets/${wallet.id}`}
 									className="block p-4 transition-colors hover:bg-zinc-50 active:bg-zinc-100 dark:hover:bg-zinc-800/50 dark:active:bg-zinc-800"
 								>
 									<div className="space-y-3">

--- a/src/utils/addressChecksum.test.ts
+++ b/src/utils/addressChecksum.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { hasValidStellarChecksum } from "@/utils/addressValidation";
+import { validateStellarAddress } from "@/utils/addressFormatting";
+
+const VALID = "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI";
+
+describe("Stellar address checksum", () => {
+	it("accepts an account ID with a valid StrKey checksum", () => {
+		expect(hasValidStellarChecksum(VALID)).toBe(true);
+		expect(validateStellarAddress(VALID)).toEqual({ valid: true });
+	});
+
+	it("rejects a structurally valid account ID with a changed checksum", () => {
+		const changed = `${VALID.slice(0, -1)}A`;
+		expect(hasValidStellarChecksum(changed)).toBe(false);
+		expect(validateStellarAddress(changed).error).toMatch(/checksum/i);
+	});
+});

--- a/src/utils/addressFormatting.ts
+++ b/src/utils/addressFormatting.ts
@@ -1,3 +1,5 @@
+import { hasValidStellarChecksum } from "@/utils/addressValidation";
+
 /**
  * Truncates a long address string for display.
  * Example: "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI" -> "GBZXN7...MADI"
@@ -40,6 +42,13 @@ export function validateStellarAddress(address: string): {
 		return {
 			valid: false,
 			error: "Address contains invalid characters (must be A-Z or 2-7).",
+		};
+	}
+
+	if (!hasValidStellarChecksum(trimmed)) {
+		return {
+			valid: false,
+			error: "Address checksum is invalid. Check the last characters and try again.",
 		};
 	}
 

--- a/src/utils/addressValidation.ts
+++ b/src/utils/addressValidation.ts
@@ -11,6 +11,55 @@ export type AddressValidationResult = {
 	fullAddress: string | null;
 };
 
+const BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+function decodeBase32(value: string): Uint8Array | null {
+	let bits = 0;
+	let buffer = 0;
+	const bytes: number[] = [];
+
+	for (const character of value) {
+		const digit = BASE32_ALPHABET.indexOf(character);
+		if (digit === -1) return null;
+		buffer = (buffer << 5) | digit;
+		bits += 5;
+		if (bits >= 8) {
+			bits -= 8;
+			bytes.push((buffer >>> bits) & 0xff);
+		}
+	}
+
+	return Uint8Array.from(bytes);
+}
+
+function crc16Xmodem(payload: Uint8Array): number {
+	let crc = 0;
+	for (const byte of payload) {
+		crc ^= byte << 8;
+		for (let bit = 0; bit < 8; bit += 1) {
+			crc = (crc & 0x8000) !== 0 ? (crc << 1) ^ 0x1021 : crc << 1;
+			crc &= 0xffff;
+		}
+	}
+	return crc;
+}
+
+/**
+ * Verifies the CRC16-XModem checksum embedded in a Stellar StrKey account ID.
+ * Stellar serializes the checksum little-endian in the final two decoded bytes.
+ */
+export function hasValidStellarChecksum(address: string): boolean {
+	const normalized = address.trim().toUpperCase();
+	if (!/^G[A-Z2-7]{55}$/.test(normalized)) return false;
+
+	const decoded = decodeBase32(normalized);
+	if (!decoded || decoded.length !== 35 || decoded[0] !== 6 << 3) return false;
+
+	const payload = decoded.slice(0, -2);
+	const expected = decoded[decoded.length - 2] | (decoded[decoded.length - 1] << 8);
+	return crc16Xmodem(payload) === expected;
+}
+
 /**
  * Validates if a string is a valid Stellar address
  * Stellar addresses start with 'G' and are 56 characters long
@@ -19,7 +68,7 @@ export type AddressValidationResult = {
  */
 export function isValidStellarAddress(address: string): boolean {
 	if (!address || typeof address !== "string") return false;
-	return /^G[A-Z2-7]{55}$/.test(address);
+	return hasValidStellarChecksum(address);
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR delivers the four related dashboard usability issues as one cohesive wallet/network/settings update.

### #495 — client-side Stellar address checksum hint

- Implements dependency-free Stellar StrKey checksum validation using Base32 decoding and CRC16-XModem.
- Extends existing address validation so a 56-character, alphabetically valid but checksum-invalid address is rejected.
- Adds an accessible live hint to the Add Wallet flow:
  - pending guidance while typing
  - success confirmation for a valid checksum
  - a specific mismatch warning for a complete invalid address
- Keeps the verification entirely client-side and network-independent.

### #496 — network in document titles and headers

- Keeps the active Mainnet/Testnet badge visible in the dashboard heading and breadcrumb.
- Synchronizes the selected network into the browser title.
- Correctly resolves dynamic wallet routes as `Wallet Detail` instead of exposing the wallet ID as a page title.
- Removes duplicate title synchronization.

### #497 — settings page shell for profile preferences

- Adds the missing primary `/dashboard/settings` route.
- Provides a responsive profile-preferences shell with:
  - authenticated user identity
  - editable display name
  - product email preference
  - compact wallet-row preference
  - local persistence and save confirmation
- Handles loading, signed-out/empty, invalid stored-data, validation, and storage failure states.
- Uses the existing dashboard layout, page header, button, and empty-state primitives.

### #498 — edit wallet nickname from detail

- Adds the missing primary `/dashboard/wallets/[id]` detail route.
- Adds accessible inline nickname editing, cancellation, validation, saving, and API failure feedback.
- Adds `PATCH /api/wallets/[id]` with not-found, malformed JSON, missing label, and invalid label handling.
- Supports clearing a nickname by saving an empty value.
- Corrects wallet table mouse/keyboard/mobile navigation to remain in `/dashboard` instead of jumping to the demo route.
- Fixes sidebar active-state matching so nested routes do not also mark Dashboard as active.

## Coverage added

- Stellar checksum utility: valid and checksum-mutated account IDs.
- Add Wallet checksum success and mismatch hints.
- Wallet detail nickname edit and PATCH request.
- Wallet nickname API success and validation rejection.
- Settings preference rendering and persistence.

Per request, tests were not run locally. This workspace does not contain installed dependencies, so formatter/type commands were also unavailable. `git diff --check` passes.

## Manual verification checklist

### Desktop

- [ ] Open Wallets, add a valid Stellar G-address, and confirm the green checksum hint.
- [ ] Change the final character and confirm the checksum mismatch hint and rejected submission.
- [ ] Switch between Mainnet and Testnet and confirm both the header badge and browser title update.
- [ ] Open a wallet row and confirm navigation stays under `/dashboard/wallets/[id]`.
- [ ] Edit, save, cancel, clear, and retry a wallet nickname.
- [ ] Open Settings, update preferences, refresh, and confirm local persistence.
- [ ] Confirm only the correct nested sidebar item is active.

### Narrow mobile viewport

- [ ] Confirm checksum text, character count, and Add Wallet actions remain readable without horizontal overflow.
- [ ] Confirm wallet cards navigate to primary wallet detail.
- [ ] Confirm nickname controls wrap cleanly and remain keyboard/touch accessible.
- [ ] Confirm Settings stacks navigation and form sections vertically.
- [ ] Confirm the network selector and title remain visible and usable.

Closes #495
Closes #496
Closes #497
Closes #498
