### PR TITLE
fix: restore corrupted toast.tsx blocking spending-limits usage meter & error handling Body:

### DIFF
--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -9,9 +9,8 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+/** Visual variant for the standalone `Toast` component. */
+export type ToastVariant = "success" | "error" | "info";
 
 /** Props for the `Toast` notification component. */
 export interface ToastProps {
@@ -67,125 +66,105 @@ export function Toast({
 		return null;
 	}
 
-export type ToastType = ToastVariant;
+	const { icon: Icon, iconClass, defaultTitle } = VARIANT_CONFIG[variant];
+	const displayTitle = title ?? defaultTitle;
+
+	return (
+		<div className="fixed right-4 bottom-4 z-50 max-w-xs rounded-2xl bg-zinc-950/95 p-4 text-white shadow-2xl ring-1 ring-white/10 backdrop-blur-md">
+			<div role="status" aria-live="polite" className="flex items-start gap-3">
+				<Icon
+					className={`mt-0.5 h-4 w-4 shrink-0 ${iconClass}`}
+					aria-hidden="true"
+				/>
+				<div className="flex-1 space-y-1">
+					<p className="text-sm font-semibold">{displayTitle}</p>
+					<p className="text-sm text-zinc-200">{message}</p>
+				</div>
+				{onClose && (
+					<button
+						onClick={onClose}
+						className="-mr-1 -mt-1 ml-auto rounded p-1 text-zinc-400 transition-colors hover:text-zinc-200"
+						aria-label="Dismiss notification"
+					>
+						<X className="h-3.5 w-3.5" aria-hidden="true" />
+					</button>
+				)}
+			</div>
+		</div>
+	);
+}
+
+// ─── Toast Container ─────────────────────────────────────────────────────────
+
+export type ToastMessageType = "success" | "error" | "info" | "warning";
 
 export interface ToastMessage {
 	id: string;
-	type: ToastType;
+	type: ToastMessageType;
 	message: string;
 	description?: string;
-	/** Duration in ms before auto-dismiss. 0 = no auto-dismiss. Default: 5000 */
+	/** Auto-dismiss delay in ms. `0` disables auto-dismiss. Defaults to 5000. */
 	duration?: number;
 }
 
-// ---------------------------------------------------------------------------
-// ToastItem — single notification
-// ---------------------------------------------------------------------------
+export type ToastPosition =
+	| "top-right"
+	| "top-left"
+	| "bottom-right"
+	| "bottom-left";
+
+export interface ToastContainerProps {
+	toasts: ToastMessage[];
+	onDismiss: (id: string) => void;
+	position?: ToastPosition;
+}
+
+const positionClasses: Record<ToastPosition, string> = {
+	"top-right": "top-4 right-4",
+	"top-left": "top-4 left-4",
+	"bottom-right": "bottom-4 right-4",
+	"bottom-left": "bottom-4 left-4",
+};
+
+const TOAST_ITEM_ICON: Record<
+	ToastMessageType,
+	{ icon: React.ElementType; iconClass: string }
+> = {
+	success: { icon: CheckCircle2, iconClass: "text-green-500" },
+	error: { icon: AlertCircle, iconClass: "text-red-500" },
+	info: { icon: Info, iconClass: "text-blue-500" },
+	warning: { icon: AlertTriangle, iconClass: "text-amber-500" },
+};
+
+const DEFAULT_TOAST_DURATION = 5000;
 
 interface ToastItemProps {
 	toast: ToastMessage;
 	onDismiss: (id: string) => void;
 }
 
-const ICONS: Record<ToastType, React.ReactNode> = {
-	success: (
-		<svg
-			className="h-5 w-5 text-green-500"
-			fill="none"
-			viewBox="0 0 24 24"
-			strokeWidth={2}
-			stroke="currentColor"
-			aria-hidden="true"
-		>
-			<path
-				strokeLinecap="round"
-				strokeLinejoin="round"
-				d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-			/>
-		</svg>
-	),
-	error: (
-		<svg
-			className="h-5 w-5 text-red-500"
-			fill="none"
-			viewBox="0 0 24 24"
-			strokeWidth={2}
-			stroke="currentColor"
-			aria-hidden="true"
-		>
-			<path
-				strokeLinecap="round"
-				strokeLinejoin="round"
-				d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"
-			/>
-		</svg>
-	),
-	info: (
-		<svg
-			className="h-5 w-5 text-blue-500"
-			fill="none"
-			viewBox="0 0 24 24"
-			strokeWidth={2}
-			stroke="currentColor"
-			aria-hidden="true"
-		>
-			<path
-				strokeLinecap="round"
-				strokeLinejoin="round"
-				d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z"
-			/>
-		</svg>
-	),
-	warning: (
-		<svg
-			className="h-5 w-5 text-yellow-500"
-			fill="none"
-			viewBox="0 0 24 24"
-			strokeWidth={2}
-			stroke="currentColor"
-			aria-hidden="true"
-		>
-			<path
-				strokeLinecap="round"
-				strokeLinejoin="round"
-				d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
-			/>
-		</svg>
-	),
-};
-
-const LABELS: Record<ToastType, string> = {
-	success: "Success",
-	error: "Error",
-	info: "Info",
-	warning: "Warning",
-};
-
+/** A single dismissible, optionally auto-expiring toast notification. */
 export function ToastItem({ toast, onDismiss }: ToastItemProps) {
-	const { id, type, message, description, duration = 5000 } = toast;
-	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const { id, type, message, description, duration } = toast;
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: only re-arm the timer when the toast identity/duration changes
 	useEffect(() => {
-		if (duration === 0) return;
-		timerRef.current = setTimeout(() => {
+		const effectiveDuration = duration ?? DEFAULT_TOAST_DURATION;
+		if (effectiveDuration === 0) return;
+
+		const timer = window.setTimeout(() => {
 			onDismiss(id);
-		}, duration);
-		return () => {
-			if (timerRef.current) clearTimeout(timerRef.current);
-		};
+		}, effectiveDuration);
+
+		return () => window.clearTimeout(timer);
 	}, [id, duration, onDismiss]);
+
+	const { icon: Icon, iconClass } = TOAST_ITEM_ICON[type];
 
 	return (
 		<div
 			role="alert"
-			aria-live="assertive"
-			className={cn(
-				"flex w-full max-w-sm items-start gap-3 rounded-xl border bg-white px-4 py-3 shadow-lg dark:bg-zinc-900",
-				type === "success" && "border-green-200 dark:border-green-800",
-				type === "error" && "border-red-200 dark:border-red-800",
-				type === "info" && "border-blue-200 dark:border-blue-800",
-				type === "warning" && "border-yellow-200 dark:border-yellow-800",
-			)}
+			className="flex items-start gap-3 rounded-xl bg-white p-4 text-zinc-900 shadow-lg ring-1 ring-zinc-200 dark:bg-zinc-900 dark:text-zinc-50 dark:ring-zinc-800"
 		>
 			<Icon
 				className={`mt-0.5 h-4 w-4 shrink-0 ${iconClass}`}
@@ -194,7 +173,7 @@ export function ToastItem({ toast, onDismiss }: ToastItemProps) {
 			<div className="flex-1 space-y-1">
 				<p className="text-sm font-semibold">{message}</p>
 				{description && (
-					<p className="mt-0.5 text-xs text-zinc-500 dark:text-zinc-400">
+					<p className="text-sm text-zinc-500 dark:text-zinc-400">
 						{description}
 					</p>
 				)}
@@ -202,47 +181,20 @@ export function ToastItem({ toast, onDismiss }: ToastItemProps) {
 			<button
 				type="button"
 				onClick={() => onDismiss(id)}
-				aria-label="Dismiss notification"
-				className="shrink-0 text-zinc-400 hover:text-zinc-600 dark:text-zinc-500 dark:hover:text-zinc-300"
+				className="ml-2 shrink-0 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+				aria-label={`Dismiss ${type} notification`}
 			>
-				<svg
-					className="h-4 w-4"
-					fill="none"
-					viewBox="0 0 24 24"
-					strokeWidth={2}
-					stroke="currentColor"
-					aria-hidden="true"
-				>
-					<path
-						strokeLinecap="round"
-						strokeLinejoin="round"
-						d="M6 18L18 6M6 6l12 12"
-					/>
-				</svg>
+				<span aria-hidden="true">&times;</span>
 			</button>
 		</div>
 	);
 }
 
-// ---------------------------------------------------------------------------
-// ToastContainer — stacks multiple toasts
-// ---------------------------------------------------------------------------
-
-type ToastPosition = "top-right" | "top-left" | "bottom-right" | "bottom-left";
-
-interface ToastContainerProps {
-	toasts: ToastMessage[];
-	onDismiss: (id: string) => void;
-	position?: ToastPosition;
-}
-
-const POSITION_CLASSES: Record<ToastPosition, string> = {
-	"top-right": "top-4 right-4",
-	"top-left": "top-4 left-4",
-	"bottom-right": "bottom-4 right-4",
-	"bottom-left": "bottom-4 left-4",
-};
-
+/**
+ * Container that renders a stack of toast notifications.
+ * Positions the toasts based on the `position` prop.
+ * Returns null when there are no toasts to display (empty state).
+ */
 export function ToastContainer({
 	toasts,
 	onDismiss,


### PR DESCRIPTION


## Summary
- Restores `src/components/ui/toast.tsx`, which had diverged into a broken, non-compiling
  state (undefined `Icon`/`cn`/`iconClass`, missing imports, missing `ToastVariant` type).
  This is the toast implementation every component actually imports, including
  `SpendingLimitsCard`, so the break was silently blocking verification of #446 and #447.
- Root cause: `Toast.tsx` and `toast.tsx` are tracked as two separate case-variant paths
  in git that collide into a single physical file on case-insensitive filesystems —
  whichever blob gets checked out last silently overwrites the other on disk.
- No feature code changed: the daily usage meter (#447) and spending-limits save error
  handling (#446) were already implemented and covered by existing tests in
  `SpendingLimitsCard.tsx` / `SpendingLimitsCard.test.tsx` — they just couldn't compile
  until this file was fixed.

## Test plan
- [x] `vitest run` — 33/33 tests passing across `toast.test.tsx`, `__tests__/toast.test.tsx`,
      and `SpendingLimitsCard.test.tsx`
- [x] Manually verified `/dashboard/spending-limits`: usage bar renders, validation errors
      show inline + as a toast, PUT failure surfaces an inline banner + toast, retry-on-load
      works, and layout adapts on a narrow viewport

Closes #446
Closes #447
closes #444