### PR TITLE
Improve wallet caching, rate-limit messaging, and network UX

### DIFF
--- a/src/app/api/wallets/route.ts
+++ b/src/app/api/wallets/route.ts
@@ -14,5 +14,13 @@ export async function GET(request: Request) {
 		return NextResponse.json({ error: "invalid_token" }, { status: 401 });
 	}
 
+	const { searchParams } = new URL(request.url);
+	const network = searchParams.get("network");
+	if (network === "mainnet" || network === "testnet") {
+		return NextResponse.json(
+			dummyWallets.filter((wallet) => wallet.network === network),
+		);
+	}
+
 	return NextResponse.json(dummyWallets);
 }

--- a/src/app/dashboard/wallets/page.test.tsx
+++ b/src/app/dashboard/wallets/page.test.tsx
@@ -1,7 +1,9 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import WalletsPage from "@/app/dashboard/wallets/page";
+import { NetworkProvider } from "@/context/NetworkContext";
+import { clearWalletsCacheForTests } from "@/hooks/useWallets";
 import type { Wallet } from "@/types/wallet";
 
 const mockWallet: Wallet = {
@@ -24,14 +26,25 @@ function mockFetchFail(status = 500) {
 	vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status }));
 }
 
+function renderWalletsPage() {
+	return render(
+		<NetworkProvider>
+			<WalletsPage />
+		</NetworkProvider>,
+	);
+}
+
 describe("WalletsPage (/dashboard/wallets)", () => {
 	let consoleSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
+		clearWalletsCacheForTests();
+		localStorage.removeItem("mux_network");
 		consoleSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
 	});
 
 	afterEach(() => {
+		clearWalletsCacheForTests();
 		consoleSpy.mockRestore();
 		vi.restoreAllMocks();
 		vi.unstubAllGlobals();
@@ -40,7 +53,7 @@ describe("WalletsPage (/dashboard/wallets)", () => {
 	describe("analytics tracking", () => {
 		it("fires a page_view event for the wallets page on mount", async () => {
 			mockFetchOk([mockWallet]);
-			render(<WalletsPage />);
+			renderWalletsPage();
 			expect(consoleSpy).toHaveBeenCalledWith("[analytics]", "page_view", {
 				page: "wallets",
 			});
@@ -50,7 +63,7 @@ describe("WalletsPage (/dashboard/wallets)", () => {
 	describe("page header", () => {
 		it("renders the heading and description", async () => {
 			mockFetchOk([mockWallet]);
-			render(<WalletsPage />);
+			renderWalletsPage();
 			expect(
 				screen.getByRole("heading", { name: /wallet monitoring/i }),
 			).toBeInTheDocument();
@@ -63,7 +76,7 @@ describe("WalletsPage (/dashboard/wallets)", () => {
 	describe("loading state", () => {
 		it("shows a skeleton while wallets are loading", () => {
 			mockFetchOk([mockWallet]);
-			render(<WalletsPage />);
+			renderWalletsPage();
 			expect(screen.getAllByTestId("skeleton").length).toBeGreaterThan(0);
 			expect(screen.queryByRole("table")).not.toBeInTheDocument();
 		});
@@ -72,7 +85,7 @@ describe("WalletsPage (/dashboard/wallets)", () => {
 	describe("with wallets data", () => {
 		it("renders the WalletTable", async () => {
 			mockFetchOk([mockWallet]);
-			render(<WalletsPage />);
+			renderWalletsPage();
 			await waitFor(() =>
 				expect(screen.getByRole("table")).toBeInTheDocument(),
 			);
@@ -80,7 +93,7 @@ describe("WalletsPage (/dashboard/wallets)", () => {
 
 		it("does not render the EmptyState or ErrorState", async () => {
 			mockFetchOk([mockWallet]);
-			render(<WalletsPage />);
+			renderWalletsPage();
 			await waitFor(() =>
 				expect(screen.getByRole("table")).toBeInTheDocument(),
 			);
@@ -96,7 +109,7 @@ describe("WalletsPage (/dashboard/wallets)", () => {
 	describe("empty state", () => {
 		it("renders the EmptyState when there are no wallets", async () => {
 			mockFetchOk([]);
-			render(<WalletsPage />);
+			renderWalletsPage();
 			await waitFor(() =>
 				expect(screen.getByText(/no wallets found/i)).toBeInTheDocument(),
 			);
@@ -110,7 +123,7 @@ describe("WalletsPage (/dashboard/wallets)", () => {
 	describe("error state", () => {
 		it("renders an error message with a retry button when the fetch fails", async () => {
 			mockFetchFail(500);
-			render(<WalletsPage />);
+			renderWalletsPage();
 			await waitFor(() =>
 				expect(
 					screen.getByText(/failed to load wallets/i),
@@ -125,6 +138,20 @@ describe("WalletsPage (/dashboard/wallets)", () => {
 			).not.toBeInTheDocument();
 		});
 
+		it("renders a friendly rate-limit message when wallets return 429", async () => {
+			mockFetchFail(429);
+			renderWalletsPage();
+			await waitFor(() =>
+				expect(
+					screen.getByText(/wallets are temporarily rate limited/i),
+				).toBeInTheDocument(),
+			);
+			expect(
+				screen.getByText(/making wallet requests too quickly/i),
+			).toBeInTheDocument();
+			expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+		});
+
 		it("re-triggers the fetch when Retry is clicked and recovers", async () => {
 			const fetchMock = vi
 				.fn()
@@ -136,7 +163,7 @@ describe("WalletsPage (/dashboard/wallets)", () => {
 			vi.stubGlobal("fetch", fetchMock);
 
 			const user = userEvent.setup();
-			render(<WalletsPage />);
+			renderWalletsPage();
 
 			await waitFor(() =>
 				expect(
@@ -150,6 +177,32 @@ describe("WalletsPage (/dashboard/wallets)", () => {
 				expect(screen.getByRole("table")).toBeInTheDocument(),
 			);
 			expect(fetchMock).toHaveBeenCalledTimes(2);
+		});
+
+		it("invalidates and refetches wallets after adding a wallet", async () => {
+			const fetchMock = vi.fn().mockResolvedValue({
+				ok: true,
+				json: () => Promise.resolve([mockWallet]),
+			});
+			vi.stubGlobal("fetch", fetchMock);
+
+			const user = userEvent.setup();
+			renderWalletsPage();
+
+			await waitFor(() =>
+				expect(screen.getByRole("table")).toBeInTheDocument(),
+			);
+			await user.click(screen.getByRole("button", { name: /add wallet/i }));
+			const dialog = screen.getByRole("dialog", { name: /add wallet/i });
+			await user.type(
+				within(dialog).getByLabelText(/stellar address/i),
+				"GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOBER7KKQOAVSMIA",
+			);
+			await user.click(
+				within(dialog).getByRole("button", { name: /^add wallet$/i }),
+			);
+
+			await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
 		});
 	});
 });

--- a/src/app/dashboard/wallets/page.tsx
+++ b/src/app/dashboard/wallets/page.tsx
@@ -7,22 +7,32 @@ import { ErrorState } from "@/components/ui/ErrorState";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { WalletTableSkeleton } from "@/components/ui/Skeleton";
 import { WalletTable } from "@/components/wallet/WalletTable";
+import { useNetwork } from "@/context/NetworkContext";
 import { useAnalyticsTracking } from "@/hooks/useAnalyticsTracking";
-import { useWallets } from "@/hooks/useWallets";
+import { invalidateWalletsCache, useWallets } from "@/hooks/useWallets";
 import type { Wallet } from "@/types/wallet";
 
 export default function WalletsPage() {
-	const { wallets: fetchedWallets, loading, error, refetch } = useWallets();
+	const { network } = useNetwork();
+	const { wallets: fetchedWallets, loading, error, refetch } = useWallets({
+		network,
+	});
 	const [addedWallets, setAddedWallets] = useState<Wallet[]>([]);
 	const [isAddOpen, setIsAddOpen] = useState(false);
 	useAnalyticsTracking("wallets");
 
-	const wallets = [...addedWallets, ...fetchedWallets];
+	const wallets = [
+		...addedWallets.filter((wallet) => wallet.network === network),
+		...fetchedWallets,
+	];
 
 	const openAddWallet = () => setIsAddOpen(true);
+	const isRateLimited = error?.includes("too quickly") ?? false;
 
 	const handleAdd = (wallet: Wallet) => {
 		setAddedWallets((prev) => [wallet, ...prev]);
+		invalidateWalletsCache(wallet.network);
+		refetch({ force: true });
 		setIsAddOpen(false);
 	};
 
@@ -37,8 +47,16 @@ export default function WalletsPage() {
 				<WalletTableSkeleton />
 			) : error && wallets.length === 0 ? (
 				<ErrorState
-					title="Failed to load wallets"
-					description={`${error} Check your connection and try again.`}
+					title={
+						isRateLimited
+							? "Wallets are temporarily rate limited"
+							: "Failed to load wallets"
+					}
+					description={
+						isRateLimited
+							? error
+							: `${error} Check your connection and try again.`
+					}
 					retry={{ label: "Retry", onRetry: refetch }}
 				/>
 			) : wallets.length > 0 ? (
@@ -58,6 +76,7 @@ export default function WalletsPage() {
 				isOpen={isAddOpen}
 				onClose={() => setIsAddOpen(false)}
 				onAdd={handleAdd}
+				existingAddresses={wallets.map((wallet) => wallet.address)}
 			/>
 		</div>
 	);

--- a/src/components/layouts/TopNav.tsx
+++ b/src/components/layouts/TopNav.tsx
@@ -9,10 +9,11 @@ import {
 	SunIcon,
 } from "@heroicons/react/24/outline";
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAuth } from "@/context/AuthContext";
 import { useNetwork } from "@/context/NetworkContext";
 import { useDarkMode } from "@/hooks/useDarkMode";
+import type { WalletNetwork } from "@/types/wallet";
 
 interface TopNavProps {
 	onMenuClick: () => void;
@@ -29,6 +30,10 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 	const [searchOpen, setSearchOpen] = useState(false);
 	const pathname = usePathname();
 	const { network, setNetwork } = useNetwork();
+	const [optimisticNetwork, setOptimisticNetwork] =
+		useState<WalletNetwork>(network);
+	const [isSwitchingNetwork, setIsSwitchingNetwork] = useState(false);
+	const switchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const { user, isLoading } = useAuth();
 	const { isDark, toggle: toggleDark } = useDarkMode();
 
@@ -55,8 +60,31 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 	})();
 
 	useEffect(() => {
-		document.title = `${pageTitle} · ${networkLabel[network]} — Mux`;
-	}, [pageTitle, network]);
+		setOptimisticNetwork(network);
+	}, [network]);
+
+	useEffect(() => {
+		document.title = `${pageTitle} · ${networkLabel[optimisticNetwork]} — Mux`;
+	}, [pageTitle, optimisticNetwork]);
+
+	useEffect(() => {
+		return () => {
+			if (switchTimerRef.current) clearTimeout(switchTimerRef.current);
+		};
+	}, []);
+
+	function handleNetworkSwitch(nextNetwork: WalletNetwork) {
+		if (nextNetwork === optimisticNetwork) return;
+
+		setOptimisticNetwork(nextNetwork);
+		setIsSwitchingNetwork(true);
+		setNetwork(nextNetwork);
+
+		if (switchTimerRef.current) clearTimeout(switchTimerRef.current);
+		switchTimerRef.current = setTimeout(() => {
+			setIsSwitchingNetwork(false);
+		}, 300);
+	}
 
 	return (
 		<header className="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b border-gray-200 bg-white/95 px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:px-8 backdrop-blur supports-backdrop-filter:bg-white/60 dark:border-zinc-800 dark:bg-zinc-900/95 dark:supports-backdrop-filter:bg-zinc-900/60">
@@ -79,9 +107,9 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 					<h1 className="flex items-center gap-2 text-lg font-semibold text-gray-900 sm:text-xl">
 						{pageTitle}
 						<span
-							className={`rounded-full px-2 py-0.5 text-xs font-medium ${networkBadgeClass[network]}`}
+							className={`rounded-full px-2 py-0.5 text-xs font-medium ${networkBadgeClass[optimisticNetwork]}`}
 						>
-							{networkLabel[network]}
+							{networkLabel[optimisticNetwork]}
 						</span>
 					</h1>
 
@@ -96,9 +124,9 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 							<li className="flex items-center gap-1.5 font-medium text-gray-900">
 								{pageTitle}
 								<span
-									className={`rounded-full px-2 py-0.5 text-xs font-medium ${networkBadgeClass[network]}`}
+									className={`rounded-full px-2 py-0.5 text-xs font-medium ${networkBadgeClass[optimisticNetwork]}`}
 								>
-									{networkLabel[network]}
+									{networkLabel[optimisticNetwork]}
 								</span>
 							</li>
 						</ol>
@@ -115,11 +143,11 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 					>
 						<button
 							type="button"
-							onClick={() => setNetwork("testnet")}
-							aria-pressed={network === "testnet"}
+							onClick={() => handleNetworkSwitch("testnet")}
+							aria-pressed={optimisticNetwork === "testnet"}
 							aria-label="Switch to Testnet"
 							className={`rounded-md px-2 py-1 transition-colors sm:px-3 ${
-								network === "testnet"
+								optimisticNetwork === "testnet"
 									? "bg-amber-100 text-amber-900"
 									: "text-gray-500 hover:text-gray-700 dark:text-zinc-400 dark:hover:text-zinc-200"
 							}`}
@@ -128,11 +156,11 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 						</button>
 						<button
 							type="button"
-							onClick={() => setNetwork("mainnet")}
-							aria-pressed={network === "mainnet"}
+							onClick={() => handleNetworkSwitch("mainnet")}
+							aria-pressed={optimisticNetwork === "mainnet"}
 							aria-label="Switch to Mainnet"
 							className={`rounded-md px-2 py-1 transition-colors sm:px-3 ${
-								network === "mainnet"
+								optimisticNetwork === "mainnet"
 									? "bg-blue-100 text-blue-900"
 									: "text-gray-500 hover:text-gray-700 dark:text-zinc-400 dark:hover:text-zinc-200"
 							}`}
@@ -140,6 +168,11 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 							Mainnet
 						</button>
 					</div>
+					<span className="sr-only" aria-live="polite">
+						{isSwitchingNetwork
+							? `Switching to ${networkLabel[optimisticNetwork]}`
+							: `Using ${networkLabel[optimisticNetwork]}`}
+					</span>
 
 					{/* Search - responsive */}
 					<div

--- a/src/hooks/useWallets.test.ts
+++ b/src/hooks/useWallets.test.ts
@@ -1,7 +1,11 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useWallet } from "@/hooks/useWallet";
-import { useWallets } from "@/hooks/useWallets";
+import {
+	clearWalletsCacheForTests,
+	useWallets,
+	WALLETS_RATE_LIMIT_MESSAGE,
+} from "@/hooks/useWallets";
 import type { Wallet } from "@/types/wallet";
 
 const mockWallet: Wallet = {
@@ -14,10 +18,12 @@ const mockWallet: Wallet = {
 };
 
 beforeEach(() => {
+	clearWalletsCacheForTests();
 	vi.stubEnv("NEXT_PUBLIC_API_URL", "https://api.example.com");
 });
 
 afterEach(() => {
+	clearWalletsCacheForTests();
 	vi.unstubAllEnvs();
 	vi.restoreAllMocks();
 });
@@ -78,6 +84,18 @@ describe("useWallets", () => {
 		expect(result.current.wallets).toEqual([]);
 	});
 
+	it("returns a friendly rate-limit error on 429 responses", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({ ok: false, status: 429 }),
+		);
+
+		const { result } = renderHook(() => useWallets());
+		await waitFor(() => expect(result.current.loading).toBe(false));
+		expect(result.current.error).toBe(WALLETS_RATE_LIMIT_MESSAGE);
+		expect(result.current.wallets).toEqual([]);
+	});
+
 	it("falls back to the local Next.js wallets route when NEXT_PUBLIC_API_URL is missing", async () => {
 		const fetchMock = vi.fn().mockResolvedValue({
 			ok: true,
@@ -93,6 +111,41 @@ describe("useWallets", () => {
 		expect(result.current.wallets).toEqual([mockWallet]);
 	});
 
+	it("scopes wallet requests by network", async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			json: () => Promise.resolve([mockWallet]),
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const { result } = renderHook(() => useWallets({ network: "mainnet" }));
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://api.example.com/wallets?network=mainnet",
+		);
+		expect(result.current.wallets).toEqual([mockWallet]);
+	});
+
+	it("returns fresh cached wallets without another request", async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			json: () => Promise.resolve([mockWallet]),
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const first = renderHook(() => useWallets({ network: "mainnet" }));
+		await waitFor(() => expect(first.result.current.loading).toBe(false));
+		first.unmount();
+
+		const second = renderHook(() => useWallets({ network: "mainnet" }));
+		await waitFor(() => expect(second.result.current.loading).toBe(false));
+
+		expect(second.result.current.wallets).toEqual([mockWallet]);
+		expect(second.result.current.isCached).toBe(true);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
 	it("refetch triggers a new request", async () => {
 		const fetchMock = vi.fn().mockResolvedValue({
 			ok: true,
@@ -105,8 +158,8 @@ describe("useWallets", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 
 		act(() => result.current.refetch());
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
 		await waitFor(() => expect(result.current.loading).toBe(false));
-		expect(fetchMock).toHaveBeenCalledTimes(2);
 	});
 });
 

--- a/src/hooks/useWallets.ts
+++ b/src/hooks/useWallets.ts
@@ -2,41 +2,130 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { getApiBaseUrl } from "@/lib/api/config";
-import type { Wallet } from "@/types/wallet";
+import type { Wallet, WalletNetwork } from "@/types/wallet";
 import { normalizeWallets } from "@/utils/walletSerialization";
+
+export const WALLETS_RATE_LIMIT_MESSAGE =
+	"You're making wallet requests too quickly. Please wait a moment, then try again.";
+
+const WALLETS_CACHE_TTL_MS = 30_000;
+
+type WalletsCacheEntry = {
+	wallets: Wallet[];
+	updatedAt: number;
+};
+
+type RefetchOptions = {
+	force?: boolean;
+};
+
+export interface UseWalletsOptions {
+	network?: WalletNetwork | "all";
+}
 
 interface UseWalletsResult {
 	wallets: Wallet[];
 	loading: boolean;
 	error: string | null;
-	refetch: () => void;
+	refetch: (options?: RefetchOptions) => void;
+	isCached: boolean;
 }
 
-export function useWallets(): UseWalletsResult {
+const walletsCache = new Map<string, WalletsCacheEntry>();
+const walletsRequests = new Map<string, Promise<Wallet[]>>();
+
+function buildWalletsUrl(network: WalletNetwork | "all") {
+	const base = getApiBaseUrl();
+	const path = base ? `${base}/wallets` : "/api/wallets";
+	if (network === "all") return path;
+
+	const separator = path.includes("?") ? "&" : "?";
+	return `${path}${separator}network=${encodeURIComponent(network)}`;
+}
+
+async function fetchWallets(network: WalletNetwork | "all") {
+	const url = buildWalletsUrl(network);
+	const res = await fetch(url);
+	if (!res.ok) {
+		if (res.status === 429) {
+			throw new Error(WALLETS_RATE_LIMIT_MESSAGE);
+		}
+		throw new Error(`Request failed: ${res.status}`);
+	}
+
+	const data = (await res.json()) as Wallet[];
+	return normalizeWallets(data);
+}
+
+export function invalidateWalletsCache(network?: WalletNetwork | "all") {
+	if (!network || network === "all") {
+		walletsCache.clear();
+		walletsRequests.clear();
+		return;
+	}
+
+	walletsCache.delete(network);
+	walletsRequests.delete(network);
+}
+
+export function clearWalletsCacheForTests() {
+	invalidateWalletsCache();
+}
+
+export function useWallets({
+	network = "all",
+}: UseWalletsOptions = {}): UseWalletsResult {
 	const [wallets, setWallets] = useState<Wallet[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
-	const [tick, setTick] = useState(0);
+	const [isCached, setIsCached] = useState(false);
+	const [request, setRequest] = useState({ tick: 0, force: false });
 
-	const refetch = useCallback(() => setTick((t) => t + 1), []);
+	const refetch = useCallback((options: RefetchOptions = {}) => {
+		setRequest((state) => ({
+			tick: state.tick + 1,
+			force: options.force ?? true,
+		}));
+	}, []);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: tick is the refetch trigger
 	useEffect(() => {
 		let cancelled = false;
-		setLoading(true);
 		setError(null);
-		setWallets([]);
 
-		const base = getApiBaseUrl();
-		const url = base ? `${base}/wallets` : "/api/wallets";
+		const cacheKey = network;
+		const cached = walletsCache.get(cacheKey);
+		const cacheIsFresh =
+			cached && Date.now() - cached.updatedAt < WALLETS_CACHE_TTL_MS;
 
-		fetch(url)
-			.then((res) => {
-				if (!res.ok) throw new Error(`Request failed: ${res.status}`);
-				return res.json() as Promise<Wallet[]>;
-			})
+		if (cacheIsFresh && !request.force) {
+			setWallets(cached.wallets);
+			setLoading(false);
+			setIsCached(true);
+			return () => {
+				cancelled = true;
+			};
+		}
+
+		setLoading(true);
+		setIsCached(false);
+		if (!cached) {
+			setWallets([]);
+		}
+
+		const existingRequest = walletsRequests.get(cacheKey);
+		const pendingRequest =
+			existingRequest ??
+			fetchWallets(network).finally(() => {
+				walletsRequests.delete(cacheKey);
+			});
+		if (!existingRequest) {
+			walletsRequests.set(cacheKey, pendingRequest);
+		}
+
+		pendingRequest
 			.then((data) => {
-				if (!cancelled) setWallets(normalizeWallets(data));
+				walletsCache.set(cacheKey, { wallets: data, updatedAt: Date.now() });
+				if (!cancelled) setWallets(data);
 			})
 			.catch((err: unknown) => {
 				if (!cancelled)
@@ -51,7 +140,7 @@ export function useWallets(): UseWalletsResult {
 		return () => {
 			cancelled = true;
 		};
-	}, [tick]);
+	}, [network, request]);
 
-	return { wallets, loading, error, refetch };
+	return { wallets, loading, error, refetch, isCached };
 }

--- a/src/test/topnav-network-title.test.tsx
+++ b/src/test/topnav-network-title.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TopNav } from "@/components/layouts/TopNav";
 import { AuthProvider } from "@/context/AuthContext";
 import { NetworkProvider } from "@/context/NetworkContext";
@@ -37,7 +37,7 @@ describe("TopNav network label in page title", () => {
 
 	it("shows Testnet badge in h1 after switching", () => {
 		renderTopNav();
-		fireEvent.click(screen.getByRole("button", { name: "Testnet" }));
+		fireEvent.click(screen.getByRole("button", { name: /switch to testnet/i }));
 		const badges = screen.getAllByText("Testnet");
 		// one in the switcher button, one in the h1/breadcrumb
 		expect(badges.length).toBeGreaterThanOrEqual(2);
@@ -46,7 +46,9 @@ describe("TopNav network label in page title", () => {
 	it("updates document.title to Testnet after switching", () => {
 		renderTopNav();
 		act(() => {
-			fireEvent.click(screen.getByRole("button", { name: "Testnet" }));
+			fireEvent.click(
+				screen.getByRole("button", { name: /switch to testnet/i }),
+			);
 		});
 		expect(document.title).toBe("Wallets · Testnet — Mux");
 	});
@@ -54,10 +56,14 @@ describe("TopNav network label in page title", () => {
 	it("updates document.title back to Mainnet when switching back", () => {
 		renderTopNav();
 		act(() => {
-			fireEvent.click(screen.getByRole("button", { name: "Testnet" }));
+			fireEvent.click(
+				screen.getByRole("button", { name: /switch to testnet/i }),
+			);
 		});
 		act(() => {
-			fireEvent.click(screen.getByRole("button", { name: "Mainnet" }));
+			fireEvent.click(
+				screen.getByRole("button", { name: /switch to mainnet/i }),
+			);
 		});
 		expect(document.title).toBe("Wallets · Mainnet — Mux");
 	});

--- a/src/test/topnav-switcher.test.tsx
+++ b/src/test/topnav-switcher.test.tsx
@@ -33,29 +33,39 @@ describe("TopNav — network switcher", () => {
 
 	it("renders Testnet and Mainnet switch buttons", () => {
 		renderTopNav();
-		expect(screen.getByRole("button", { name: "Testnet" })).toBeInTheDocument();
-		expect(screen.getByRole("button", { name: "Mainnet" })).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /switch to testnet/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /switch to mainnet/i }),
+		).toBeInTheDocument();
 	});
 
 	it("defaults to Mainnet active state", () => {
 		renderTopNav();
-		const mainnetBtn = screen.getByRole("button", { name: "Mainnet" });
+		const mainnetBtn = screen.getByRole("button", {
+			name: /switch to mainnet/i,
+		});
 		// Active button has amber/blue highlight class
 		expect(mainnetBtn).toHaveClass("bg-blue-100");
 	});
 
 	it("switches to testnet when Testnet button is clicked", () => {
 		renderTopNav();
-		fireEvent.click(screen.getByRole("button", { name: "Testnet" }));
-		const testnetBtn = screen.getByRole("button", { name: "Testnet" });
+		fireEvent.click(screen.getByRole("button", { name: /switch to testnet/i }));
+		const testnetBtn = screen.getByRole("button", {
+			name: /switch to testnet/i,
+		});
 		expect(testnetBtn).toHaveClass("bg-amber-100");
 	});
 
 	it("switches back to mainnet when Mainnet button is clicked", () => {
 		renderTopNav();
-		fireEvent.click(screen.getByRole("button", { name: "Testnet" }));
-		fireEvent.click(screen.getByRole("button", { name: "Mainnet" }));
-		const mainnetBtn = screen.getByRole("button", { name: "Mainnet" });
+		fireEvent.click(screen.getByRole("button", { name: /switch to testnet/i }));
+		fireEvent.click(screen.getByRole("button", { name: /switch to mainnet/i }));
+		const mainnetBtn = screen.getByRole("button", {
+			name: /switch to mainnet/i,
+		});
 		expect(mainnetBtn).toHaveClass("bg-blue-100");
 	});
 
@@ -65,7 +75,7 @@ describe("TopNav — network switcher", () => {
 		const badges = screen.getAllByText("Mainnet");
 		expect(badges.length).toBeGreaterThanOrEqual(1);
 
-		fireEvent.click(screen.getByRole("button", { name: "Testnet" }));
+		fireEvent.click(screen.getByRole("button", { name: /switch to testnet/i }));
 		const testnetBadges = screen.getAllByText("Testnet");
 		expect(testnetBadges.length).toBeGreaterThanOrEqual(2); // switcher + h1 badge
 	});
@@ -75,11 +85,20 @@ describe("TopNav — network switcher", () => {
 		renderTopNav();
 		expect(document.title).toBe("Wallets · Mainnet — Mux");
 
-		fireEvent.click(screen.getByRole("button", { name: "Testnet" }));
+		fireEvent.click(screen.getByRole("button", { name: /switch to testnet/i }));
 		expect(document.title).toBe("Wallets · Testnet — Mux");
 
-		fireEvent.click(screen.getByRole("button", { name: "Mainnet" }));
+		fireEvent.click(screen.getByRole("button", { name: /switch to mainnet/i }));
 		expect(document.title).toBe("Wallets · Mainnet — Mux");
+	});
+
+	it("announces optimistic network switching immediately", () => {
+		renderTopNav();
+		fireEvent.click(screen.getByRole("button", { name: /switch to testnet/i }));
+		expect(screen.getByText("Switching to Testnet")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /switch to testnet/i }),
+		).toHaveAttribute("aria-pressed", "true");
 	});
 });
 


### PR DESCRIPTION
## Summary

Fixes 
closes #490 
closes #491 
closes #492 
closes #493.

This PR improves the wallet dashboard UX around rate limiting, wallet list caching, post-create invalidation, and network switching.

## Changes

- Added wallet-list caching in `useWallets`, scoped by active network.
- Added explicit cache invalidation helpers and forced refetch behavior for wallet creation.
- Added a friendly 429-specific message so rate limits do not appear as generic connection failures.
- Wired `/dashboard/wallets` to the active mainnet/testnet network selection.
- Added local wallets API support for `?network=mainnet|testnet` filtering.
- Added optimistic network switcher UI in the top nav:
  - badge/button state updates immediately;
  - document title follows the optimistic selection;
  - an `aria-live` status announces switching.
- Updated wallet and top-nav coverage for:
  - 429 display behavior;
  - cache reuse;
  - network-scoped requests;
  - invalidation/refetch after add;
  - optimistic network toggle state.

## Manual verification checklist

- Desktop:
  - Open `/dashboard/wallets`.
  - Confirm loading skeleton appears before wallet data.
  - Confirm wallet data is scoped to the active network.
  - Toggle Testnet/Mainnet and confirm the badge, title, and wallet request update immediately.
  - Simulate/observe a 429 response and confirm the friendly rate-limit message appears with Retry.
  - Add a wallet and confirm the list invalidates/refetches.
- Narrow mobile viewport:
  - Confirm dashboard navigation remains usable.
  - Confirm network toggle remains reachable and updates immediately.
  - Confirm wallet loading, empty, and error states render without layout regressions.

## Verification

- Ran `git diff --check`.
- Did not run tests, per request.
