### PR TITLE
Fix dashboard requests widget and accessibility gaps

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,16 +43,18 @@ export default function Home() {
 				<div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
 					{/* Your API Key button - keep your functionality but use their styling */}
 					<button
+						type="button"
 						onClick={() => setIsModalOpen(true)}
-						className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-blue-600 px-5 text-white transition-colors hover:bg-blue-700 md:w-[158px] whitespace-nowrap"
+						className="flex h-12 w-full items-center justify-center gap-2 whitespace-nowrap rounded-full bg-blue-600 px-5 text-white transition-colors hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-black md:w-[158px]"
 					>
 						+ Create API Key
 					</button>
 
 					{/* Their Deploy Now button */}
 					<a
-						className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-39.5"
+						className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:hover:bg-[#ccc] dark:focus-visible:ring-offset-black md:w-39.5"
 						href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
+						aria-label="Deploy this app with Vercel"
 						target="_blank"
 						rel="noopener noreferrer"
 					>
@@ -68,7 +70,7 @@ export default function Home() {
 
 					{/* Their Documentation link - keep their styling */}
 					<a
-						className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/8 px-5 transition-colors hover:border-transparent hover:bg-black/4 dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-39.5"
+						className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/8 px-5 transition-colors hover:border-transparent hover:bg-black/4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:border-white/[.145] dark:hover:bg-[#1a1a1a] dark:focus-visible:ring-offset-black md:w-39.5"
 						href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
 						target="_blank"
 						rel="noopener noreferrer"

--- a/src/components/APIKeyModal.test.tsx
+++ b/src/components/APIKeyModal.test.tsx
@@ -44,6 +44,7 @@ describe("APIKeyModal", () => {
 		await waitFor(() => {
 			expect(onKeyCreated).toHaveBeenCalledWith({
 				name: "Test Key",
+				value: expect.any(String),
 				key: expect.any(String),
 			});
 		});
@@ -56,7 +57,7 @@ describe("APIKeyModal", () => {
 		fireEvent.click(generateButton);
 
 		await waitFor(() => {
-			expect(screen.getByText(/please enter a name/i)).toBeInTheDocument();
+			expect(screen.getByText(/key name is required/i)).toBeInTheDocument();
 		});
 	});
 
@@ -78,6 +79,15 @@ describe("APIKeyModal", () => {
 
 		const closeButton = screen.getByText("Close");
 		fireEvent.click(closeButton);
+
+		expect(onClose).toHaveBeenCalled();
+	});
+
+	it("closes when Escape is pressed", () => {
+		const onClose = vi.fn();
+		render(<APIKeyModal isOpen={true} onClose={onClose} />);
+
+		fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
 
 		expect(onClose).toHaveBeenCalled();
 	});

--- a/src/components/APIKeyModal.tsx
+++ b/src/components/APIKeyModal.tsx
@@ -1,11 +1,26 @@
 "use client";
 
-import { useState } from "react";
+import { Check, Copy, Key, X } from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { createFocusTrapHandler } from "@/utils/keyboardNavigation";
+
+interface CreatedApiKey {
+	name: string;
+	value: string;
+	key: string;
+}
 
 interface APIKeyModalProps {
 	isOpen: boolean;
 	onClose: () => void;
-	onKeyCreated?: (key: { name: string; value: string }) => void;
+	onKeyCreated?: (key: CreatedApiKey) => void;
+}
+
+function createApiKey(): string {
+	return `mux_live_${Math.random().toString(36).slice(2, 15)}${Math.random()
+		.toString(36)
+		.slice(2, 15)}`;
 }
 
 export default function APIKeyModal({
@@ -13,115 +28,244 @@ export default function APIKeyModal({
 	onClose,
 	onKeyCreated,
 }: APIKeyModalProps) {
-	const [showWarning, setShowWarning] = useState(true);
+	const titleId = useId();
+	const descriptionId = useId();
+	const nameId = useId();
+	const errorId = useId();
+	const dialogRef = useRef<HTMLDivElement>(null);
+	const previousFocusRef = useRef<HTMLElement | null>(null);
+
+	const [keyName, setKeyName] = useState("");
 	const [apiKey, setApiKey] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
 	const [copied, setCopied] = useState(false);
+	const [acknowledged, setAcknowledged] = useState(false);
+	const [isSubmitting, setIsSubmitting] = useState(false);
 
-	const generateApiKey = () => {
-		// Generate a mock API key for UI purposes
-		const newKey = `mux_${Math.random().toString(36).substring(2, 15)}${Math.random().toString(36).substring(2, 15)}`;
-		setApiKey(newKey);
-		setShowWarning(false);
-		onKeyCreated?.({ name: "New API Key", value: newKey });
-	};
+	const isRevealStep = apiKey !== null;
 
-	const copyToClipboard = async () => {
-		if (apiKey) {
-			await navigator.clipboard.writeText(apiKey);
-			setCopied(true);
-			setTimeout(() => setCopied(false), 2000);
-		}
+	useEffect(() => {
+		if (!isOpen) return;
+		previousFocusRef.current = document.activeElement as HTMLElement | null;
+		const id = window.setTimeout(() => {
+			const firstFocusable = dialogRef.current?.querySelector<HTMLElement>(
+				'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+			);
+			firstFocusable?.focus();
+		}, 0);
+
+		return () => {
+			window.clearTimeout(id);
+			previousFocusRef.current?.focus?.();
+		};
+	}, [isOpen]);
+
+	const reset = () => {
+		setKeyName("");
+		setApiKey(null);
+		setError(null);
+		setCopied(false);
+		setAcknowledged(false);
+		setIsSubmitting(false);
 	};
 
 	const handleClose = () => {
-		setShowWarning(true);
-		setApiKey(null);
-		setCopied(false);
+		reset();
 		onClose();
+	};
+
+	const generateApiKey = async () => {
+		const trimmedName = keyName.trim();
+		if (!trimmedName) {
+			setError("Key name is required.");
+			return;
+		}
+
+		setError(null);
+		setIsSubmitting(true);
+		await Promise.resolve();
+
+		const newKey = createApiKey();
+		setApiKey(newKey);
+		setIsSubmitting(false);
+		onKeyCreated?.({ name: trimmedName, value: newKey, key: newKey });
+	};
+
+	const copyToClipboard = async () => {
+		if (!apiKey) return;
+		await navigator.clipboard.writeText(apiKey);
+		setCopied(true);
+		window.setTimeout(() => setCopied(false), 2000);
 	};
 
 	if (!isOpen) return null;
 
 	return (
-		<div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-			<div className="bg-white dark:bg-zinc-900 rounded-lg shadow-lg max-w-md w-full mx-4">
-				<div className="border-b border-zinc-200 dark:border-zinc-800 p-6">
-					<h2 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">
-						Create API Key
-					</h2>
+		<div
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby={titleId}
+			aria-describedby={descriptionId}
+			ref={dialogRef}
+			onKeyDown={(event) => {
+				createFocusTrapHandler(dialogRef)(event);
+				if (event.key === "Escape") {
+					event.preventDefault();
+					handleClose();
+				}
+			}}
+			className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+		>
+			<div
+				className="absolute inset-0"
+				aria-hidden="true"
+				onClick={handleClose}
+			/>
+
+			<div className="relative w-full max-w-md overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-xl dark:border-zinc-800 dark:bg-zinc-950">
+				<div className="flex items-center justify-between border-b border-zinc-200 p-6 dark:border-zinc-800">
+					<div className="flex items-center gap-3">
+						<div className="flex h-10 w-10 items-center justify-center rounded-lg bg-zinc-100 dark:bg-zinc-900">
+							<Key className="h-5 w-5 text-zinc-600 dark:text-zinc-400" aria-hidden="true" />
+						</div>
+						<div>
+							<h2
+								id={titleId}
+								className="text-xl font-semibold text-zinc-900 dark:text-zinc-50"
+							>
+								{isRevealStep ? "Save your API key" : "Create API Key"}
+							</h2>
+							<p
+								id={descriptionId}
+								className="text-sm text-zinc-500 dark:text-zinc-400"
+							>
+								{isRevealStep
+									? "This key will only be shown once."
+									: "Name the key before generating a secret."}
+							</p>
+						</div>
+					</div>
+					<Button
+						type="button"
+						variant="ghost"
+						size="icon-sm"
+						onClick={handleClose}
+						aria-label="Close dialog"
+					>
+						<X className="h-4 w-4" aria-hidden="true" />
+					</Button>
 				</div>
 
-				<div className="p-6 space-y-6">
-					{showWarning && !apiKey && (
-						<div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4">
-							<div className="flex gap-3">
-								<div className="text-amber-600 dark:text-amber-500 text-xl leading-none mt-0.5">
-									⚠️
-								</div>
-								<div>
-									<h3 className="font-semibold text-amber-900 dark:text-amber-200 mb-1">
-										Save your API key
-									</h3>
-									<p className="text-sm text-amber-800 dark:text-amber-300">
-										This key will only be displayed once. Make sure to copy and
-										store it somewhere safe. You won't be able to see it again.
-									</p>
-								</div>
-							</div>
-						</div>
-					)}
-
-					{apiKey ? (
-						<div className="space-y-4">
-							<div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-4">
-								<p className="text-sm font-medium text-green-900 dark:text-green-200">
-									✓ API Key successfully created
-								</p>
+				<div className="space-y-5 p-6">
+					{isRevealStep ? (
+						<>
+							<div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/40 dark:text-amber-100">
+								This key will only be shown once. Copy it now and store it in a
+								secure secret manager before closing this dialog.
 							</div>
 
 							<div>
-								<label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2">
-									Your API Key:
+								<label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+									Generated API key
 								</label>
 								<div className="flex gap-2">
-									<div className="flex-1 bg-zinc-100 dark:bg-zinc-800 border border-zinc-300 dark:border-zinc-700 rounded px-3 py-2 font-mono text-sm text-zinc-900 dark:text-zinc-50 overflow-x-auto">
-										{apiKey}
-									</div>
-									<button
-										onClick={copyToClipboard}
-										className={`px-4 py-2 rounded font-medium transition-colors ${
-											copied
-												? "bg-green-500 text-white"
-												: "bg-zinc-200 dark:bg-zinc-700 text-zinc-900 dark:text-zinc-50 hover:bg-zinc-300 dark:hover:bg-zinc-600"
-										}`}
+									<code
+										data-testid="generated-key"
+										className="min-w-0 flex-1 overflow-x-auto rounded-md border border-zinc-300 bg-zinc-50 px-3 py-2 font-mono text-sm text-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-50"
 									>
-										{copied ? "✓ Copied" : "Copy"}
-									</button>
+										{apiKey}
+									</code>
+									<Button
+										type="button"
+										variant="outline"
+										onClick={copyToClipboard}
+										data-testid="copy-generated-key"
+										aria-label={copied ? "API key copied" : "Copy API key"}
+									>
+										{copied ? (
+											<Check className="h-4 w-4 text-green-600" aria-hidden="true" />
+										) : (
+											<Copy className="h-4 w-4" aria-hidden="true" />
+										)}
+										{copied ? "Copied" : "Copy"}
+									</Button>
 								</div>
+								{copied && (
+									<p role="status" className="mt-2 text-sm text-green-700 dark:text-green-400">
+										API key copied to clipboard
+									</p>
+								)}
 							</div>
-						</div>
+
+							<label className="flex items-start gap-2 text-sm text-zinc-700 dark:text-zinc-300">
+								<input
+									type="checkbox"
+									checked={acknowledged}
+									onChange={(event) => setAcknowledged(event.target.checked)}
+									data-testid="acknowledge-checkbox"
+									className="mt-0.5 h-4 w-4 rounded border-zinc-300 text-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+								/>
+								I have copied this key and understand it cannot be viewed again.
+							</label>
+						</>
 					) : (
-						<p className="text-zinc-600 dark:text-zinc-400">
-							Click the button below to generate a new API key. Remember to save
-							it securely as you won't be able to view it again.
-						</p>
+						<>
+							<div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/40 dark:text-amber-100">
+								Save your API key after it is generated. It will only be
+								displayed once.
+							</div>
+							<div>
+								<label
+									htmlFor={nameId}
+									className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+								>
+									Key name
+								</label>
+								<input
+									id={nameId}
+									type="text"
+									value={keyName}
+									onChange={(event) => {
+										setKeyName(event.target.value);
+										if (error) setError(null);
+									}}
+									aria-invalid={!!error}
+									aria-describedby={error ? errorId : undefined}
+									className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 outline-none transition-colors focus:border-blue-500 focus:ring-2 focus:ring-blue-500/30 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-50"
+									placeholder="Production backend"
+								/>
+								{error && (
+									<p id={errorId} role="alert" className="mt-2 text-sm text-red-600 dark:text-red-400">
+										{error}
+									</p>
+								)}
+							</div>
+						</>
 					)}
 				</div>
 
-				<div className="border-t border-zinc-200 dark:border-zinc-800 p-6 flex gap-3 justify-end">
-					<button
-						onClick={handleClose}
-						className="px-4 py-2 rounded font-medium border border-zinc-300 dark:border-zinc-700 text-zinc-900 dark:text-zinc-50 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
-					>
-						Close
-					</button>
-					{!apiKey && (
-						<button
-							onClick={generateApiKey}
-							className="px-4 py-2 rounded font-medium bg-blue-600 text-white hover:bg-blue-700 transition-colors"
+				<div className="flex justify-end gap-3 border-t border-zinc-200 p-6 dark:border-zinc-800">
+					<Button type="button" variant="outline" onClick={handleClose}>
+						{isRevealStep ? "Close" : "Cancel"}
+					</Button>
+					{isRevealStep ? (
+						<Button
+							type="button"
+							onClick={handleClose}
+							disabled={!acknowledged}
+							data-testid="done-btn"
 						>
-							Generate Key
-						</button>
+							Done
+						</Button>
+					) : (
+						<Button
+							type="button"
+							onClick={() => void generateApiKey()}
+							disabled={isSubmitting}
+							data-testid="generate-key-btn"
+						>
+							{isSubmitting ? "Generating…" : "Generate Key"}
+						</Button>
 					)}
 				</div>
 			</div>

--- a/src/components/__tests__/APIKeyModal.test.tsx
+++ b/src/components/__tests__/APIKeyModal.test.tsx
@@ -104,4 +104,27 @@ describe("APIKeyModal — one-time key reveal", () => {
 		await user.click(screen.getByRole("button", { name: /close dialog/i }));
 		expect(onClose).toHaveBeenCalledOnce();
 	});
+
+	it("closes with Escape", async () => {
+		const user = userEvent.setup();
+		const onClose = vi.fn();
+		render(<APIKeyModal isOpen onClose={onClose} />);
+		await user.keyboard("{Escape}");
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+
+	it("keeps Tab focus inside the dialog", async () => {
+		const user = userEvent.setup();
+		render(<APIKeyModal isOpen onClose={vi.fn()} />);
+
+		const closeButton = screen.getByRole("button", { name: /close dialog/i });
+		const generateButton = screen.getByTestId("generate-key-btn");
+
+		closeButton.focus();
+		await user.keyboard("{Shift>}{Tab}{/Shift}");
+		expect(generateButton).toHaveFocus();
+
+		await user.tab();
+		expect(closeButton).toHaveFocus();
+	});
 });

--- a/src/components/dashboard/ApiKeysTable.tsx
+++ b/src/components/dashboard/ApiKeysTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Check, Copy, Key, RefreshCw, Shield, ShieldOff } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import APIKeyModal from "@/components/APIKeyModal";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -17,6 +17,7 @@ import {
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { cn } from "@/lib/utils";
 import { type ApiKey, mockApiKeys } from "@/mock-data/api-keys";
+import { createFocusTrapHandler } from "@/utils/keyboardNavigation";
 
 // ---------------------------------------------------------------------------
 // Revoke confirmation — inline per-row
@@ -28,12 +29,27 @@ interface RevokeConfirmProps {
 }
 
 function RevokeConfirm({ keyName, onConfirm, onCancel }: RevokeConfirmProps) {
+	const dialogRef = useRef<HTMLDivElement>(null);
+	const confirmRef = useRef<HTMLButtonElement>(null);
+
+	useEffect(() => {
+		confirmRef.current?.focus();
+	}, []);
+
 	return (
 		<div
 			role="alertdialog"
 			aria-modal="true"
 			aria-labelledby="revoke-title"
 			aria-describedby="revoke-desc"
+			ref={dialogRef}
+			onKeyDown={(event) => {
+				createFocusTrapHandler(dialogRef)(event);
+				if (event.key === "Escape") {
+					event.preventDefault();
+					onCancel();
+				}
+			}}
 			className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
 		>
 			<div className="w-full max-w-sm rounded-xl border border-zinc-200 bg-white p-6 shadow-xl dark:border-zinc-800 dark:bg-zinc-950">
@@ -61,6 +77,7 @@ function RevokeConfirm({ keyName, onConfirm, onCancel }: RevokeConfirmProps) {
 						Cancel
 					</Button>
 					<Button
+						ref={confirmRef}
 						variant="destructive"
 						size="sm"
 						onClick={onConfirm}
@@ -84,12 +101,27 @@ interface RotateConfirmProps {
 }
 
 function RotateConfirm({ keyName, onConfirm, onCancel }: RotateConfirmProps) {
+	const dialogRef = useRef<HTMLDivElement>(null);
+	const confirmRef = useRef<HTMLButtonElement>(null);
+
+	useEffect(() => {
+		confirmRef.current?.focus();
+	}, []);
+
 	return (
 		<div
 			role="alertdialog"
 			aria-modal="true"
 			aria-labelledby="rotate-title"
 			aria-describedby="rotate-desc"
+			ref={dialogRef}
+			onKeyDown={(event) => {
+				createFocusTrapHandler(dialogRef)(event);
+				if (event.key === "Escape") {
+					event.preventDefault();
+					onCancel();
+				}
+			}}
 			className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
 		>
 			<div className="w-full max-w-sm rounded-xl border border-zinc-200 bg-white p-6 shadow-xl dark:border-zinc-800 dark:bg-zinc-950">
@@ -116,7 +148,12 @@ function RotateConfirm({ keyName, onConfirm, onCancel }: RotateConfirmProps) {
 					<Button variant="outline" size="sm" onClick={onCancel}>
 						Cancel
 					</Button>
-					<Button size="sm" onClick={onConfirm} data-testid="confirm-rotate">
+					<Button
+						ref={confirmRef}
+						size="sm"
+						onClick={onConfirm}
+						data-testid="confirm-rotate"
+					>
 						Rotate key
 					</Button>
 				</div>
@@ -137,7 +174,7 @@ function CopyKeyButton({ apiKey }: { apiKey: ApiKey }) {
 			<button
 				type="button"
 				onClick={() => copy(apiKey.key)}
-				className="p-1 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
+				className="rounded p-1 transition-colors hover:text-zinc-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:hover:text-zinc-100 dark:focus-visible:ring-offset-zinc-950"
 				title={copied ? "Copied!" : "Copy to clipboard"}
 				aria-label={copied ? "Copied!" : `Copy key ${apiKey.name}`}
 				data-testid={`copy-key-${apiKey.id}`}
@@ -291,7 +328,7 @@ export function ApiKeysTable({ initialKeys = mockApiKeys }: ApiKeysTableProps) {
 							onClick={() => setStatusFilter(f)}
 							aria-pressed={statusFilter === f}
 							className={cn(
-								"rounded-full px-3 py-1 text-xs font-medium transition-colors",
+								"rounded-full px-3 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-zinc-950",
 								statusFilter === f
 									? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
 									: "text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200",

--- a/src/components/dashboard/RequestsToday.tsx
+++ b/src/components/dashboard/RequestsToday.tsx
@@ -1,27 +1,41 @@
 "use client";
+
+import { AlertCircle, RefreshCw } from "lucide-react";
 import React from "react";
+
+const REQUESTS_TODAY_ENDPOINT = "/api/requests/today";
+
+function formatRequestCount(count: number): string {
+	return new Intl.NumberFormat("en-US").format(count);
+}
 
 export default function RequestsToday() {
 	const [count, setCount] = React.useState<number | null>(null);
 	const [loading, setLoading] = React.useState(true);
 	const [error, setError] = React.useState<string | null>(null);
 
-	React.useEffect(() => {
+	const loadRequestsToday = React.useCallback(() => {
 		let mounted = true;
 		setLoading(true);
-		fetch("/api/requests/today")
+		setError(null);
+		fetch(REQUESTS_TODAY_ENDPOINT)
 			.then((res) => {
 				if (!res.ok) throw new Error(`Request failed: ${res.status}`);
 				return res.json();
 			})
 			.then((data) => {
 				if (!mounted) return;
-				if (typeof data?.count === "number") setCount(data.count);
-				else setError("invalid response");
+				if (typeof data?.count === "number" && data.count >= 0) {
+					setCount(data.count);
+				} else {
+					setCount(null);
+					setError("The requests total was not available.");
+				}
 			})
 			.catch((err) => {
 				if (!mounted) return;
-				setError(err?.message || "fetch error");
+				setCount(null);
+				setError(err?.message || "Unable to load requests today.");
 			})
 			.finally(() => {
 				if (!mounted) return;
@@ -32,12 +46,77 @@ export default function RequestsToday() {
 		};
 	}, []);
 
-	if (loading) return <div>Loading API requests today…</div>;
-	if (error) return <div>Error loading requests: {error}</div>;
+	React.useEffect(() => {
+		return loadRequestsToday();
+	}, [loadRequestsToday]);
+
 	return (
-		<div className="rounded-lg border p-4">
-			<h3 className="text-sm text-zinc-500">API requests today</h3>
-			<p className="mt-1 text-2xl font-semibold">{count ?? "—"}</p>
-		</div>
+		<section
+			aria-labelledby="requests-today-title"
+			className="rounded-xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-950"
+		>
+			<div className="flex items-start justify-between gap-4">
+				<div>
+					<h2
+						id="requests-today-title"
+						className="text-sm font-medium text-zinc-500 dark:text-zinc-400"
+					>
+						API requests today
+					</h2>
+					<p className="mt-1 text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
+						{loading ? (
+							<span
+								aria-label="Loading API requests today"
+								className="inline-block h-9 w-28 animate-pulse rounded bg-zinc-200 align-middle dark:bg-zinc-800"
+							/>
+						) : error ? (
+							<span aria-label="Requests today unavailable">—</span>
+						) : count === null ? (
+							<span aria-label="No requests today">0</span>
+						) : (
+							formatRequestCount(count)
+						)}
+					</p>
+				</div>
+
+				<button
+					type="button"
+					onClick={loadRequestsToday}
+					disabled={loading}
+					className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-zinc-200 text-zinc-500 transition-colors hover:bg-zinc-50 hover:text-zinc-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-900 dark:hover:text-zinc-50 dark:focus-visible:ring-offset-zinc-950"
+					aria-label="Refresh API requests today"
+				>
+					<RefreshCw
+						className={`h-4 w-4 ${loading ? "animate-spin" : ""}`}
+						aria-hidden="true"
+					/>
+				</button>
+			</div>
+
+			{loading ? (
+				<p role="status" className="mt-4 text-sm text-zinc-500 dark:text-zinc-400">
+					Loading API requests today…
+				</p>
+			) : error ? (
+				<div
+					role="alert"
+					className="mt-4 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-950/40 dark:text-red-200"
+				>
+					<AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+					<div>
+						<p className="font-medium">Requests could not be loaded.</p>
+						<p className="mt-0.5">{error}</p>
+					</div>
+				</div>
+			) : count === 0 || count === null ? (
+				<p className="mt-4 text-sm text-zinc-500 dark:text-zinc-400">
+					No API requests have been recorded today.
+				</p>
+			) : (
+				<p className="mt-4 text-sm text-zinc-500 dark:text-zinc-400">
+					Counted from the active API environment for the current day.
+				</p>
+			)}
+		</section>
 	);
 }

--- a/src/components/dashboard/__tests__/RequestsToday.test.tsx
+++ b/src/components/dashboard/__tests__/RequestsToday.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
-import { vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import RequestsToday from "../RequestsToday";
 
 describe("RequestsToday", () => {
@@ -21,6 +21,53 @@ describe("RequestsToday", () => {
 		expect(screen.getByText(/loading api requests today/i)).toBeInTheDocument();
 		await waitFor(() => {
 			expect(screen.getByText("123")).toBeInTheDocument();
+		});
+	});
+
+	it("renders an empty state when there are no requests", async () => {
+		global.fetch = vi.fn(() =>
+			Promise.resolve({
+				ok: true,
+				json: () => Promise.resolve({ count: 0 }),
+			}),
+		) as unknown as typeof fetch;
+
+		render(<RequestsToday />);
+
+		await waitFor(() => {
+			expect(
+				screen.getByText(/no api requests have been recorded today/i),
+			).toBeInTheDocument();
+		});
+	});
+
+	it("renders an error state and retries the request", async () => {
+		global.fetch = vi
+			.fn()
+			.mockResolvedValueOnce({
+				ok: false,
+				status: 500,
+				json: () => Promise.resolve({}),
+			})
+			.mockResolvedValueOnce({
+				ok: true,
+				json: () => Promise.resolve({ count: 42 }),
+			}) as unknown as typeof fetch;
+
+		render(<RequestsToday />);
+
+		await waitFor(() => {
+			expect(
+				screen.getByText(/requests could not be loaded/i),
+			).toBeInTheDocument();
+		});
+
+		fireEvent.click(
+			screen.getByRole("button", { name: /refresh api requests today/i }),
+		);
+
+		await waitFor(() => {
+			expect(screen.getByText("42")).toBeInTheDocument();
 		});
 	});
 });

--- a/src/components/layouts/Sidebar.tsx
+++ b/src/components/layouts/Sidebar.tsx
@@ -72,7 +72,8 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
 						<button
 							type="button"
 							onClick={onClose}
-							className="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-500 lg:hidden"
+							aria-label="Close sidebar"
+							className="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 lg:hidden"
 						>
 							<span className="sr-only">Close sidebar</span>
 							<XMarkIcon className="h-6 w-6" aria-hidden="true" />
@@ -88,7 +89,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
 									key={item.name}
 									href={item.href}
 									className={clsx(
-										"group flex items-center rounded-lg px-4 py-3 text-sm font-medium transition-colors duration-200",
+										"group flex items-center rounded-lg px-4 py-3 text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2",
 										isActive
 											? "bg-blue-50 text-blue-700 border border-blue-200"
 											: "text-gray-700 hover:bg-gray-50 hover:text-gray-900",

--- a/src/components/layouts/TopNav.tsx
+++ b/src/components/layouts/TopNav.tsx
@@ -64,7 +64,8 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 			<button
 				type="button"
 				onClick={onMenuClick}
-				className="-m-2.5 p-2.5 text-gray-700 lg:hidden"
+				aria-label="Open sidebar"
+				className="-m-2.5 rounded-md p-2.5 text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 lg:hidden"
 			>
 				<span className="sr-only">Open sidebar</span>
 				<Bars3Icon className="h-6 w-6" aria-hidden="true" />
@@ -118,7 +119,7 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 							onClick={() => setNetwork("testnet")}
 							aria-pressed={network === "testnet"}
 							aria-label="Switch to Testnet"
-							className={`rounded-md px-2 py-1 transition-colors sm:px-3 ${
+							className={`rounded-md px-2 py-1 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-zinc-800 sm:px-3 ${
 								network === "testnet"
 									? "bg-amber-100 text-amber-900"
 									: "text-gray-500 hover:text-gray-700 dark:text-zinc-400 dark:hover:text-zinc-200"
@@ -131,7 +132,7 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 							onClick={() => setNetwork("mainnet")}
 							aria-pressed={network === "mainnet"}
 							aria-label="Switch to Mainnet"
-							className={`rounded-md px-2 py-1 transition-colors sm:px-3 ${
+							className={`rounded-md px-2 py-1 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-zinc-800 sm:px-3 ${
 								network === "mainnet"
 									? "bg-blue-100 text-blue-900"
 									: "text-gray-500 hover:text-gray-700 dark:text-zinc-400 dark:hover:text-zinc-200"
@@ -165,7 +166,8 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 					<button
 						type="button"
 						onClick={() => setSearchOpen(!searchOpen)}
-						className="p-2 text-gray-400 hover:text-gray-500 lg:hidden"
+						aria-label={searchOpen ? "Close search" : "Open search"}
+						className="rounded-md p-2 text-gray-400 hover:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 lg:hidden"
 					>
 						<span className="sr-only">Search</span>
 						<MagnifyingGlassIcon className="h-5 w-5" aria-hidden="true" />
@@ -188,6 +190,7 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 					{/* Notifications */}
 					<button
 						type="button"
+						aria-label="View notifications"
 						className="relative rounded-full p-1 text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
 					>
 						<span className="sr-only">View notifications</span>
@@ -199,6 +202,7 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 					<div className="relative">
 						<button
 							type="button"
+							aria-label="Open user menu"
 							className="flex items-center gap-x-3 rounded-lg p-1.5 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
 							id="user-menu-button"
 						>

--- a/src/components/wallet/AddWalletModal.tsx
+++ b/src/components/wallet/AddWalletModal.tsx
@@ -19,6 +19,7 @@ import {
 	validateStellarAddress,
 } from "@/utils/addressFormatting";
 import { hasValidStellarChecksum } from "@/utils/addressValidation";
+import { createFocusTrapHandler } from "@/utils/keyboardNavigation";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -93,6 +94,7 @@ export function AddWalletModal({
 
 	const addressInputRef = useRef<HTMLInputElement>(null);
 	const closeButtonRef = useRef<HTMLButtonElement>(null);
+	const dialogRef = useRef<HTMLDivElement>(null);
 
 	// Focus address input when modal opens
 	useEffect(() => {
@@ -218,6 +220,10 @@ export function AddWalletModal({
 			role="dialog"
 			aria-modal="true"
 			aria-labelledby="add-wallet-title"
+			ref={dialogRef}
+			onKeyDown={(event) => {
+				createFocusTrapHandler(dialogRef)(event);
+			}}
 			className="fixed inset-0 z-50 flex items-center justify-center p-4"
 		>
 			{/* Backdrop */}

--- a/src/components/wallet/ReceiveWalletModal.tsx
+++ b/src/components/wallet/ReceiveWalletModal.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { AlertCircle, Check, Copy, QrCode, X } from "lucide-react";
-import { useEffect, useId } from "react";
+import { useEffect, useId, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import type { Wallet } from "@/types/wallet";
 import { isValidStellarAddress } from "@/utils/addressValidation";
+import { createFocusTrapHandler } from "@/utils/keyboardNavigation";
 
 interface ReceiveWalletModalProps {
 	isOpen: boolean;
@@ -84,6 +85,7 @@ export default function ReceiveWalletModal({
 }: ReceiveWalletModalProps) {
 	const titleId = useId();
 	const descriptionId = useId();
+	const dialogRef = useRef<HTMLDivElement>(null);
 	const { copy, copied, error } = useCopyToClipboard();
 
 	const address = wallet?.address.trim() ?? "";
@@ -110,6 +112,10 @@ export default function ReceiveWalletModal({
 			aria-modal="true"
 			aria-labelledby={titleId}
 			aria-describedby={descriptionId}
+			ref={dialogRef}
+			onKeyDown={(event) => {
+				createFocusTrapHandler(dialogRef)(event);
+			}}
 			className="fixed inset-0 z-50 flex items-center justify-center p-4"
 		>
 			<div

--- a/src/components/wallet/SendWalletModal.tsx
+++ b/src/components/wallet/SendWalletModal.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { AlertCircle, SendHorizonal, X } from "lucide-react";
-import { useId, useState } from "react";
+import { useId, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import type { Wallet } from "@/types/wallet";
 import { isValidStellarAddress } from "@/utils/addressValidation";
+import { createFocusTrapHandler } from "@/utils/keyboardNavigation";
 
 interface SendWalletModalProps {
 	isOpen: boolean;
@@ -62,6 +63,7 @@ export function SendWalletModal({
 	const amountId = useId();
 	const destinationErrorId = useId();
 	const amountErrorId = useId();
+	const dialogRef = useRef<HTMLDivElement>(null);
 
 	const [destination, setDestination] = useState("");
 	const [amount, setAmount] = useState("");
@@ -105,6 +107,14 @@ export function SendWalletModal({
 			role="dialog"
 			aria-modal="true"
 			aria-labelledby={titleId}
+			ref={dialogRef}
+			onKeyDown={(event) => {
+				createFocusTrapHandler(dialogRef)(event);
+				if (event.key === "Escape") {
+					event.preventDefault();
+					handleClose();
+				}
+			}}
 			className="fixed inset-0 z-50 flex items-center justify-center p-4"
 		>
 			<div

--- a/src/utils/keyboardNavigation.ts
+++ b/src/utils/keyboardNavigation.ts
@@ -97,7 +97,7 @@ export function getArrowDirection(
  * Keeps focus within specified elements
  */
 export function createFocusTrapHandler(
-	containerRef: React.RefObject<HTMLElement>,
+	containerRef: React.RefObject<HTMLElement | null>,
 ): (event: React.KeyboardEvent) => void {
 	return (event: React.KeyboardEvent) => {
 		if (!isKey(parseKeyboardEvent(event), "Tab")) return;
@@ -105,10 +105,7 @@ export function createFocusTrapHandler(
 		const container = containerRef.current;
 		if (!container) return;
 
-		// Get all focusable elements
-		const focusableElements = container.querySelectorAll(
-			'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-		) as NodeListOf<HTMLElement>;
+		const focusableElements = getFocusableElements(container);
 
 		if (focusableElements.length === 0) return;
 


### PR DESCRIPTION
## Summary
- Adds a production-shaped Requests Today dashboard widget with loading, empty, error, and retry states.
- Reworks API key creation into an accessible one-time reveal dialog with key naming, copy feedback, acknowledgement, Escape close, and focus trapping.
- Adds keyboard focus trapping to wallet and API-key confirmation dialogs, plus visible focus rings and accessible labels for relevant icon-only dashboard controls.
- Updates targeted Testing Library coverage for Requests Today and modal keyboard behavior.

## Validation
- Ran: git diff --check.
- Attempted: TypeScript noEmit. Blocked because dependencies are not installed locally and npx attempted a network registry lookup.

## Manual checklist
- Desktop: open Dashboard, confirm Requests Today loads, retry works after an API error, and dashboard nav remains accessible.
- Mobile/narrow viewport: open sidebar/search controls, verify visible focus rings and labels.
- Modal keyboard: open API key, wallet receive/send/add wallet, rotate/revoke dialogs; verify Tab stays inside and Escape closes where supported.

Closes #479
Closes #480
Closes #481
Closes #482