### PR TITLE
feat: implement wallets fetch, skeleton, empty state, and network fil…

### DIFF
--- a/src/app/dashboard/wallets/page.test.tsx
+++ b/src/app/dashboard/wallets/page.test.tsx
@@ -15,6 +15,24 @@ const mockWallet: Wallet = {
 	balance: "1,250.50 XLM",
 };
 
+const mockMainnetWallet: Wallet = {
+	id: "wallet-m1",
+	address: "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI",
+	network: "mainnet",
+	status: "active",
+	createdAt: new Date("2024-01-15T10:30:00Z"),
+	balance: "1,250.50 XLM",
+};
+
+const mockTestnetWallet: Wallet = {
+	id: "wallet-t1",
+	address: "GCFONE23AB7Y6C5YZOMKUKGETPIAJA752ZPMORQO5VKA6LHXHC7Y3YPE",
+	network: "testnet",
+	status: "active",
+	createdAt: new Date("2024-02-20T08:15:00Z"),
+	balance: "500.00 XLM",
+};
+
 function mockFetchOk(data: unknown) {
 	vi.stubGlobal(
 		"fetch",
@@ -203,6 +221,201 @@ describe("WalletsPage (/dashboard/wallets)", () => {
 			);
 
 			await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// #423 – Network filter
+	// ---------------------------------------------------------------------------
+	describe("network filter (#423)", () => {
+		it("renders the network filter buttons after wallets load", async () => {
+			mockFetchOk([mockMainnetWallet, mockTestnetWallet]);
+			renderWalletsPage();
+
+			await waitFor(() =>
+				expect(screen.getByRole("group", { name: /network filter/i })).toBeInTheDocument(),
+			);
+			expect(
+				screen.getByRole("button", { name: /filter by all networks/i }),
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole("button", { name: /filter by testnet/i }),
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole("button", { name: /filter by mainnet/i }),
+			).toBeInTheDocument();
+		});
+
+		it("shows all wallets when 'All Networks' is selected (default)", async () => {
+			mockFetchOk([mockMainnetWallet, mockTestnetWallet]);
+			renderWalletsPage();
+
+			await waitFor(() =>
+				expect(screen.getByRole("table")).toBeInTheDocument(),
+			);
+
+			// All Networks is selected by default
+			expect(
+				screen.getByRole("button", { name: /filter by all networks/i }),
+			).toHaveAttribute("aria-pressed", "true");
+
+			// Both wallets should be in the table
+			const rows = screen.getAllByRole("row");
+			expect(rows.length).toBeGreaterThanOrEqual(3); // header + 2 wallets
+		});
+
+		it("shows only mainnet wallets when Mainnet filter is selected", async () => {
+			mockFetchOk([mockMainnetWallet, mockTestnetWallet]);
+			const user = userEvent.setup();
+			renderWalletsPage();
+
+			await waitFor(() =>
+				expect(screen.getByRole("table")).toBeInTheDocument(),
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: /filter by mainnet/i }),
+			);
+
+			// Mainnet button should now be active
+			expect(
+				screen.getByRole("button", { name: /filter by mainnet/i }),
+			).toHaveAttribute("aria-pressed", "true");
+
+			// Only mainnet wallet row should appear (header + 1 data row)
+			const rows = screen.getAllByRole("row");
+			expect(rows).toHaveLength(2);
+		});
+
+		it("shows only testnet wallets when Testnet filter is selected", async () => {
+			mockFetchOk([mockMainnetWallet, mockTestnetWallet]);
+			const user = userEvent.setup();
+			renderWalletsPage();
+
+			await waitFor(() =>
+				expect(screen.getByRole("table")).toBeInTheDocument(),
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: /filter by testnet/i }),
+			);
+
+			expect(
+				screen.getByRole("button", { name: /filter by testnet/i }),
+			).toHaveAttribute("aria-pressed", "true");
+
+			// Only testnet wallet row (header + 1 data row)
+			const rows = screen.getAllByRole("row");
+			expect(rows).toHaveLength(2);
+		});
+
+		it("restores all wallets when switching back to 'All Networks'", async () => {
+			mockFetchOk([mockMainnetWallet, mockTestnetWallet]);
+			const user = userEvent.setup();
+			renderWalletsPage();
+
+			await waitFor(() =>
+				expect(screen.getByRole("table")).toBeInTheDocument(),
+			);
+
+			// Filter to mainnet
+			await user.click(
+				screen.getByRole("button", { name: /filter by mainnet/i }),
+			);
+			expect(screen.getAllByRole("row")).toHaveLength(2);
+
+			// Switch back to all
+			await user.click(
+				screen.getByRole("button", { name: /filter by all networks/i }),
+			);
+
+			expect(
+				screen.getByRole("button", { name: /filter by all networks/i }),
+			).toHaveAttribute("aria-pressed", "true");
+			// Both wallets visible again
+			const rows = screen.getAllByRole("row");
+			expect(rows.length).toBeGreaterThanOrEqual(3);
+		});
+
+		it("shows a network-specific empty state when no wallets match the selected filter", async () => {
+			// Only mainnet wallets in the response
+			mockFetchOk([mockMainnetWallet]);
+			const user = userEvent.setup();
+			renderWalletsPage();
+
+			await waitFor(() =>
+				expect(screen.getByRole("table")).toBeInTheDocument(),
+			);
+
+			// Select testnet — no wallets match
+			await user.click(
+				screen.getByRole("button", { name: /filter by testnet/i }),
+			);
+
+			await waitFor(() =>
+				expect(
+					screen.getByText(/no wallets on this network/i),
+				).toBeInTheDocument(),
+			);
+			expect(screen.queryByRole("table")).not.toBeInTheDocument();
+		});
+
+		it("the 'Show all networks' action in the network empty state resets the filter", async () => {
+			mockFetchOk([mockMainnetWallet]);
+			const user = userEvent.setup();
+			renderWalletsPage();
+
+			await waitFor(() =>
+				expect(screen.getByRole("table")).toBeInTheDocument(),
+			);
+
+			// Filter to testnet to get empty state
+			await user.click(
+				screen.getByRole("button", { name: /filter by testnet/i }),
+			);
+
+			await waitFor(() =>
+				expect(
+					screen.getByText(/no wallets on this network/i),
+				).toBeInTheDocument(),
+			);
+
+			// Click 'Show all networks' action
+			await user.click(
+				screen.getByRole("button", { name: /show all networks/i }),
+			);
+
+			// Should return to the table with all wallets
+			await waitFor(() =>
+				expect(screen.getByRole("table")).toBeInTheDocument(),
+			);
+			expect(
+				screen.queryByText(/no wallets on this network/i),
+			).not.toBeInTheDocument();
+		});
+
+		it("does not show the network filter while wallets are still loading", () => {
+			mockFetchOk([mockMainnetWallet]);
+			renderWalletsPage();
+
+			// Loading state: skeleton visible, network filter hidden
+			expect(screen.getAllByTestId("skeleton").length).toBeGreaterThan(0);
+			expect(
+				screen.queryByRole("group", { name: /network filter/i }),
+			).not.toBeInTheDocument();
+		});
+
+		it("disables the network filter buttons when the fetch fails and no wallets are cached", async () => {
+			mockFetchFail(500);
+			renderWalletsPage();
+
+			await waitFor(() =>
+				expect(screen.getByText(/failed to load wallets/i)).toBeInTheDocument(),
+			);
+
+			const filterGroup = screen.getByRole("group", { name: /network filter/i });
+			const buttons = within(filterGroup).getAllByRole("button");
+			buttons.forEach((btn) => expect(btn).toBeDisabled());
 		});
 	});
 });

--- a/src/app/dashboard/wallets/page.tsx
+++ b/src/app/dashboard/wallets/page.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { AddWalletModal } from "@/components/wallet/AddWalletModal";
+import { NetworkFilter } from "@/components/wallet/NetworkFilter";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { ErrorState } from "@/components/ui/ErrorState";
 import { PageHeader } from "@/components/ui/PageHeader";
@@ -9,6 +10,7 @@ import { WalletTableSkeleton } from "@/components/ui/Skeleton";
 import { WalletTable } from "@/components/wallet/WalletTable";
 import { useNetwork } from "@/context/NetworkContext";
 import { useAnalyticsTracking } from "@/hooks/useAnalyticsTracking";
+import { useNetworkFilter } from "@/hooks/useNetworkFilter";
 import { invalidateWalletsCache, useWallets } from "@/hooks/useWallets";
 import type { Wallet } from "@/types/wallet";
 
@@ -20,12 +22,37 @@ export default function WalletsPage() {
 	const [addedWallets, setAddedWallets] = useState<Wallet[]>([]);
 	const [isAddOpen, setIsAddOpen] = useState(false);
 	const [showArchived, setShowArchived] = useState(false);
+	const { selectedNetwork, setSelectedNetwork, filterByNetwork } =
+		useNetworkFilter();
 	useAnalyticsTracking("wallets");
 
-	const wallets = [
-		...addedWallets.filter((wallet) => wallet.network === network),
-		...fetchedWallets,
-	];
+	// Combine optimistically-added wallets (scoped to current network) with fetched ones
+	const wallets = useMemo(
+		() => [
+			...addedWallets.filter((wallet) => wallet.network === network),
+			...fetchedWallets,
+		],
+		[addedWallets, fetchedWallets, network],
+	);
+
+	// Apply network filter then archived filter
+	const networkFilteredWallets = useMemo(
+		() => filterByNetwork(wallets),
+		[filterByNetwork, wallets],
+	);
+
+	const archivedCount = useMemo(
+		() => networkFilteredWallets.filter((w) => w.archived).length,
+		[networkFilteredWallets],
+	);
+
+	const visibleWallets = useMemo(
+		() =>
+			showArchived
+				? networkFilteredWallets
+				: networkFilteredWallets.filter((w) => !w.archived),
+		[networkFilteredWallets, showArchived],
+	);
 
 	const openAddWallet = () => setIsAddOpen(true);
 	const isRateLimited = error?.includes("too quickly") ?? false;
@@ -58,6 +85,15 @@ export default function WalletsPage() {
 				)}
 			</div>
 
+			{/* #423: Network filter — client-side filter on top of the network-scoped fetch */}
+			{!loading && (
+				<NetworkFilter
+					selectedNetwork={selectedNetwork}
+					onNetworkChange={setSelectedNetwork}
+					disabled={!!error && wallets.length === 0}
+				/>
+			)}
+
 			{loading ? (
 				<WalletTableSkeleton />
 			) : error && wallets.length === 0 ? (
@@ -76,10 +112,19 @@ export default function WalletsPage() {
 				/>
 			) : visibleWallets.length > 0 ? (
 				<WalletTable wallets={visibleWallets} onAddWallet={openAddWallet} />
+			) : wallets.length > 0 && networkFilteredWallets.length === 0 ? (
+				<EmptyState
+					title="No wallets on this network"
+					description={`No wallets found for the selected network filter. Try selecting "All Networks".`}
+					action={{
+						label: "Show all networks",
+						onClick: () => setSelectedNetwork("all"),
+					}}
+				/>
 			) : wallets.length > 0 ? (
 				<EmptyState
 					title="No wallets to show"
-					description="All of your wallets are archived. Toggle “Show archived” to see them."
+					description={`All of your wallets are archived. Toggle "Show archived" to see them.`}
 				/>
 			) : (
 				<EmptyState

--- a/src/hooks/useWallets.ts
+++ b/src/hooks/useWallets.ts
@@ -2,9 +2,22 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { getApiBaseUrl } from "@/lib/api/config";
-import type { Wallet } from "@/types/wallet";
+import type { Wallet, WalletNetwork } from "@/types/wallet";
 import { fetchWithAuth } from "@/utils/fetchWithAuth";
 import { normalizeWallets } from "@/utils/walletSerialization";
+
+/** Reads the stored session token from localStorage (client-side only). */
+function getStoredAccessToken(): string | null {
+	if (typeof window === "undefined") return null;
+	try {
+		const raw = localStorage.getItem("mux-auth-session");
+		if (!raw) return null;
+		const session = JSON.parse(raw) as { accessToken?: string };
+		return session?.accessToken ?? null;
+	} catch {
+		return null;
+	}
+}
 
 export const WALLETS_RATE_LIMIT_MESSAGE =
 	"You're making wallet requests too quickly. Please wait a moment, then try again.";
@@ -46,7 +59,17 @@ function buildWalletsUrl(network: WalletNetwork | "all") {
 
 async function fetchWallets(network: WalletNetwork | "all") {
 	const url = buildWalletsUrl(network);
-	const res = await fetch(url);
+
+	const headers: Record<string, string> = {
+		"Content-Type": "application/json",
+	};
+
+	const token = getStoredAccessToken();
+	if (token) {
+		headers["Authorization"] = `Bearer ${token}`;
+	}
+
+	const res = await fetchWithAuth(url, { headers });
 	if (!res.ok) {
 		if (res.status === 429) {
 			throw new Error(WALLETS_RATE_LIMIT_MESSAGE);


### PR DESCRIPTION
feat: wallets list fetch, loading skeleton, empty states, and network
  filter
  
  Closes #419
  Closes  #420,
  Closes #421
  Closes  #423
  
  ────────────────────────────────────────────────────────────────────────
  
  What changed
  
  Fetch wallets from backend API (#419)
  
  - useWallets hook fetches from the configured API URL with auth headers,
  network scoping, 30s caching, and automatic refetch on wallet add
  - Falls back to the local /api/wallets route when NEXT_PUBLIC_API_URL is
  unset, so dev mode works without a live backend
  - Handles 429 rate-limit responses with a user-friendly message
  
  Loading skeleton (#420)
  
  - WalletTableSkeleton renders while the fetch is in-flight — table and
  empty state are never shown until data resolves
  - Network filter is hidden during loading to avoid interaction before
  data is ready
  
  Empty states (#421)
  
  - No wallets: prompt to add the first wallet
  - All archived: hint to toggle "Show archived"
  - No match on network filter: "No wallets on this network" with a
  one-click reset to All Networks
  
  Network filter (#423)
  
  - NetworkFilter (All / Testnet / Mainnet) renders after load, above the
  table
  - Client-side filter via useNetworkFilter — no extra network requests on
  switch
  - Disabled when a fetch error leaves the list empty
  - Optimistically-added wallets are scoped to the active network and
  included in filter results
  
  Bug fix
  
  - WalletNetwork was referenced but not imported in useWallets.ts — added
  to the type import
  
  ────────────────────────────────────────────────────────────────────────
  
  Tests added
  
  8 new page-level integration tests in page.test.tsx covering:
  
  - Network filter buttons visible after load, hidden during loading
  - Mainnet / testnet filters show only matching wallets
  - Switching back to All Networks restores full list
  - Network-specific empty state renders and resets correctly
  - Filter buttons disabled on fetch error with no cached wallets
  
  ────────────────────────────────────────────────────────────────────────
  
  Manual checklist
  
  - [ ] Wallets load on desktop and narrow mobile viewport
  - [ ] Skeleton visible on initial load, gone after data arrives
  - [ ] Empty state shown when no wallets exist
  - [ ] Network filter switches between All / Testnet / Mainnet correctly
  - [ ] "Show all networks" action in empty state resets the filter
  - [ ] Retry button on error state re-triggers the fetch and recovers