### PR TITLE
fix: repair broken toast component so limits save toast renders

### DIFF
--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -16,22 +16,6 @@ import {
 import { cn } from "@/lib/utils";
 
 /** Visual variant for the standalone `Toast` component. */
-export type ToastVariant = "success" | "error" | "info";
-
-export type ToastVariant = "success" | "error" | "info" | "warning";
-
-export type ToastVariant = "success" | "error" | "info" | "warning";
-
-export type ToastVariant = "success" | "error" | "info" | "warning";
-
-export type ToastVariant = "success" | "error" | "info" | "warning";
-
-export type ToastVariant = "success" | "error" | "info" | "warning";
-
-export type ToastVariant = "success" | "error" | "info" | "warning";
-
-export type ToastVariant = "success" | "error" | "info" | "warning";
-
 export type ToastVariant = "success" | "error" | "info" | "warning";
 
 /** Props for the `Toast` notification component. */
@@ -163,6 +147,13 @@ const TOAST_ITEM_ICON: Record<
 	warning: { icon: AlertTriangle, iconClass: "text-amber-500" },
 };
 
+const TOAST_ITEM_LABEL: Record<ToastMessageType, string> = {
+	success: "Success",
+	error: "Error",
+	info: "Info",
+	warning: "Warning",
+};
+
 const DEFAULT_TOAST_DURATION = 5000;
 
 interface ToastItemProps {
@@ -193,9 +184,9 @@ export function ToastItem({ toast, onDismiss }: ToastItemProps) {
 			role="alert"
 			className="flex items-start gap-3 rounded-xl bg-white p-4 text-zinc-900 shadow-lg ring-1 ring-zinc-200 dark:bg-zinc-900 dark:text-zinc-50 dark:ring-zinc-800"
 		>
-			<span className="mt-0.5 shrink-0">{ICONS[type]}</span>
+			<Icon className={`mt-0.5 h-4 w-4 shrink-0 ${iconClass}`} aria-hidden="true" />
 			<div className="flex-1 space-y-1">
-				<p className="text-sm font-semibold">{LABELS[type]}</p>
+				<p className="text-sm font-semibold">{TOAST_ITEM_LABEL[type]}</p>
 				<p className="text-sm text-zinc-600 dark:text-zinc-300">{message}</p>
 				{description && (
 					<p className="text-sm text-zinc-500 dark:text-zinc-400">
@@ -230,7 +221,7 @@ export function ToastContainer({
 	return (
 		<div
 			aria-label="Notifications"
-			className={`fixed z-50 flex flex-col gap-2 w-full max-w-sm ${POSITION_CLASSES[position]}`}
+			className={`fixed z-50 flex flex-col gap-2 w-full max-w-sm ${positionClasses[position]}`}
 		>
 			{toasts.map((toast) => (
 				<ToastItem key={toast.id} toast={toast} onDismiss={onDismiss} />


### PR DESCRIPTION
Title: Fix broken Toast component so limits save toast renders

Summary
src/components/ui/toast.tsx had duplicate ToastVariant type exports and referenced undefined identifiers (ICONS, LABELS, POSITION_CLASSES) instead of the actual constants defined in the file (TOAST_ITEM_ICON, a new TOAST_ITEM_LABEL map, positionClasses), which broke the component.
SpendingLimitsCard already calls showToast("success", "Spending limits saved.") on successful save and renders <Toast />, but the toast never worked because the underlying component didn't compile/render correctly.
Fixed the identifier mismatches and de-duplicated the type export so the existing save-success toast flow works as intended.
Test plan
 Manually verify: open the limits card, change a value, save, confirm the success toast appears and auto-dismisses
 Manually verify the error toast path (e.g. invalid input) still renders correctly
 Check on a narrow mobile viewport
Closes #445