### PR TITLE
fix: clear cached wallet data and repair the TopNav sign-out flow on …

### DIFF
--- a/src/components/layouts/TopNav.tsx
+++ b/src/components/layouts/TopNav.tsx
@@ -9,7 +9,7 @@ import {
 	MoonIcon,
 	SunIcon,
 } from "@heroicons/react/24/outline";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { useAuth } from "@/context/AuthContext";
 import { useNetwork } from "@/context/NetworkContext";
@@ -36,7 +36,7 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 		useState<WalletNetwork>(network);
 	const [isSwitchingNetwork, setIsSwitchingNetwork] = useState(false);
 	const switchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-	const { user, isLoading } = useAuth();
+	const { user, isLoading, signOut } = useAuth();
 	const { isDark, toggle: toggleDark } = useDarkMode();
 	const router = useRouter();
 	const menuRef = useRef<HTMLDivElement>(null);
@@ -117,98 +117,6 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 		signOut();
 		router.replace("/login");
 	}
-
-	const displayName = user?.name ?? "Developer";
-
-	// Close dropdown when clicking outside
-	useEffect(() => {
-		function handleClickOutside(event: MouseEvent) {
-			if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-				setMenuOpen(false);
-			}
-		}
-		document.addEventListener("mousedown", handleClickOutside);
-		return () => document.removeEventListener("mousedown", handleClickOutside);
-	}, []);
-
-	// Close dropdown on Escape key
-	useEffect(() => {
-		function handleKeyDown(event: KeyboardEvent) {
-			if (event.key === "Escape") {
-				setMenuOpen(false);
-			}
-		}
-		document.addEventListener("keydown", handleKeyDown);
-		return () => document.removeEventListener("keydown", handleKeyDown);
-	}, []);
-
-	function handleLogout() {
-		setMenuOpen(false);
-		signOut();
-		router.replace("/login");
-	}
-
-	const displayName = user?.name ?? "Developer";
-
-	// Close dropdown when clicking outside
-	useEffect(() => {
-		function handleClickOutside(event: MouseEvent) {
-			if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-				setMenuOpen(false);
-			}
-		}
-		document.addEventListener("mousedown", handleClickOutside);
-		return () => document.removeEventListener("mousedown", handleClickOutside);
-	}, []);
-
-	// Close dropdown on Escape key
-	useEffect(() => {
-		function handleKeyDown(event: KeyboardEvent) {
-			if (event.key === "Escape") {
-				setMenuOpen(false);
-			}
-		}
-		document.addEventListener("keydown", handleKeyDown);
-		return () => document.removeEventListener("keydown", handleKeyDown);
-	}, []);
-
-	function handleLogout() {
-		setMenuOpen(false);
-		signOut();
-		router.replace("/login");
-	}
-
-	const displayName = user?.name ?? "Developer";
-
-	// Close dropdown when clicking outside
-	useEffect(() => {
-		function handleClickOutside(event: MouseEvent) {
-			if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-				setMenuOpen(false);
-			}
-		}
-		document.addEventListener("mousedown", handleClickOutside);
-		return () => document.removeEventListener("mousedown", handleClickOutside);
-	}, []);
-
-	// Close dropdown on Escape key
-	useEffect(() => {
-		function handleKeyDown(event: KeyboardEvent) {
-			if (event.key === "Escape") {
-				setMenuOpen(false);
-			}
-		}
-		document.addEventListener("keydown", handleKeyDown);
-		return () => document.removeEventListener("keydown", handleKeyDown);
-	}, []);
-
-	function handleLogout() {
-		setMenuOpen(false);
-		signOut();
-		router.replace("/login");
-	}
-
-	const displayName = user?.name ?? "Developer";
 
 	return (
 		<header className="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b border-gray-200 bg-white/95 px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:px-8 backdrop-blur supports-backdrop-filter:bg-white/60 dark:border-zinc-800 dark:bg-zinc-900/95 dark:supports-backdrop-filter:bg-zinc-900/60">
@@ -359,7 +267,10 @@ export function TopNav({ onMenuClick }: TopNavProps) {
 					<div className="relative" ref={menuRef}>
 						<button
 							type="button"
+							onClick={() => setMenuOpen((open) => !open)}
 							aria-label="Open user menu"
+							aria-haspopup="true"
+							aria-expanded={menuOpen}
 							className="flex items-center gap-x-3 rounded-lg p-1.5 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
 							id="user-menu-button"
 						>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -7,9 +7,11 @@ import {
 	useEffect,
 	useState,
 } from "react";
-import { 
-	trackAuthEvent, 
-	trackSessionExpired 
+import { invalidateWalletsCache } from "@/hooks/useWallets";
+import { resetWalletsPrefetchCache } from "@/lib/walletsPrefetchCache";
+import {
+	trackAuthEvent,
+	trackSessionExpired,
 } from "@/services/authAnalyticsTracking";
 
 export interface AuthUser {
@@ -133,7 +135,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 					// Re-sync cookie in case it was cleared (e.g. browser restart)
 					const remainingMs = record.expiresAt - Date.now();
 					setSessionCookie(remainingMs);
-					trackAuthEvent("session_rehydrated", { 
+					trackAuthEvent("session_rehydrated", {
 						email: record.user.email,
 						remainingMs,
 					});
@@ -167,8 +169,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 		const currentUser = user;
 		sessionStorage.removeItem(SESSION_STORAGE_KEY);
 		clearSessionCookie();
+		// Drop cached wallet data so the next session (or a different user on
+		// the same device) never sees a stale, pre-logout list before refetching.
+		invalidateWalletsCache();
+		resetWalletsPrefetchCache();
 		setUser(null);
-		trackAuthEvent("logout", { 
+		trackAuthEvent("logout", {
 			email: currentUser?.email,
 		});
 	}, [user]);

--- a/src/context/__tests__/AuthContext.test.ts
+++ b/src/context/__tests__/AuthContext.test.ts
@@ -12,7 +12,9 @@
 
 import { act, renderHook, waitFor } from "@testing-library/react";
 import React from "react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as useWalletsModule from "@/hooks/useWallets";
+import * as walletsPrefetchCache from "@/lib/walletsPrefetchCache";
 import {
 	AuthProvider,
 	SESSION_COOKIE_NAME,
@@ -168,9 +170,7 @@ describe("AuthContext — session lifecycle (issue #46)", () => {
 	it("useAuth throws when called outside of AuthProvider", () => {
 		// In React 19 + RTL 14, a hook that throws during render propagates the
 		// error directly from renderHook rather than landing in result.error.
-		expect(() => renderHook(() => useAuth())).toThrow(
-			/AuthProvider/,
-		);
+		expect(() => renderHook(() => useAuth())).toThrow(/AuthProvider/);
 	});
 
 	it("signOut clears the mux_auth_session cookie", async () => {
@@ -189,6 +189,33 @@ describe("AuthContext — session lifecycle (issue #46)", () => {
 
 		// Cookie max-age=0 removes it; jsdom represents it as an empty value
 		expect(document.cookie).not.toMatch(new RegExp(`${SESSION_COOKIE_NAME}=1`));
+	});
+
+	it("signOut clears cached wallet data so no stale data leaks into the next session", async () => {
+		const invalidateSpy = vi.spyOn(useWalletsModule, "invalidateWalletsCache");
+		const resetPrefetchSpy = vi.spyOn(
+			walletsPrefetchCache,
+			"resetWalletsPrefetchCache",
+		);
+
+		const record = {
+			user: { name: "Jane", email: "jane@example.com", role: "admin" },
+			expiresAt: Date.now() + 60_000,
+		};
+		sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(record));
+
+		const { result } = renderHook(() => useAuth(), { wrapper });
+		await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+
+		act(() => {
+			result.current.signOut();
+		});
+
+		expect(invalidateSpy).toHaveBeenCalled();
+		expect(resetPrefetchSpy).toHaveBeenCalled();
+
+		invalidateSpy.mockRestore();
+		resetPrefetchSpy.mockRestore();
 	});
 
 	it("isAuthenticated reflects signIn/signOut transitions", async () => {

--- a/src/lib/walletsPrefetchCache.ts
+++ b/src/lib/walletsPrefetchCache.ts
@@ -62,7 +62,12 @@ export function getWalletsPrefetchEntry(): Promise<Wallet[]> | null {
 	return cacheEntry.promise;
 }
 
+/** Clears the in-memory prefetch cache, e.g. on logout so no stale wallet data survives into the next session. */
+export function resetWalletsPrefetchCache(): void {
+	cacheEntry = null;
+}
+
 /** Test-only helper to reset module-level cache state between tests. */
 export function __resetWalletsPrefetchCacheForTests(): void {
-	cacheEntry = null;
+	resetWalletsPrefetchCache();
 }


### PR DESCRIPTION
Summary
Logging out left stale wallet data behind: signOut() only cleared the auth session (sessionStorage + cookie) but never touched the in-memory wallet caches in useWallets and walletsPrefetchCache, so a subsequent session (or a different user on a shared device) could briefly see the previous user's wallets before a fresh fetch completed.
TopNav's user-menu dropdown was also non-functional: the "Open user menu" button had no click handler at all, so the dropdown (and the Sign out action inside it) could never be opened from the UI. The surrounding logout handler, click-outside/escape effects, and displayName were additionally duplicated four times over (leftover merge artifact) and useRouter was never imported, so the file didn't compile.
Fixed both: signOut() now invalidates the wallets cache and resets the prefetch cache, and TopNav is repaired to a single, working dropdown/logout flow with proper aria-haspopup/aria-expanded wiring.
Changes
src/context/AuthContext.tsx — signOut() now calls invalidateWalletsCache() and resetWalletsPrefetchCache() in addition to clearing sessionStorage/cookie.
src/lib/walletsPrefetchCache.ts — added a non-test-only resetWalletsPrefetchCache() export (the existing __resetWalletsPrefetchCacheForTests now delegates to it).
src/components/layouts/TopNav.tsx — removed the duplicated handleLogout/effects/displayName blocks, added the missing useRouter import, destructured signOut from useAuth(), and wired the user-menu button's onClick (plus aria-haspopup/aria-expanded) so the dropdown actually opens.
src/context/__tests__/AuthContext.test.ts — added a test asserting signOut() clears the wallet caches.
Out of scope
src/components/layouts/Sidebar.tsx has no logout entry point at all, and LogoutAction.test.tsx has a pre-existing, still-skipped suite of Sidebar tests for it — that's tracked separately under issue #45 and wasn't touched here to keep this change focused.
Left other pre-existing issues alone (e.g. an unrelated getStoredAccessToken dead-code path reading a stale localStorage key in useWallets.ts, and unrelated typecheck errors in APIKeyModal.tsx / ApiKeysTable.tsx) since they're outside this issue's scope.
Test plan
 pnpm vitest run src/context/__tests__/AuthContext.test.ts — all pass except one pre-existing flaky test unrelated to this change (starts with isLoading=true and user=null, fails identically on staging before this branch's changes).
 pnpm vitest run src/components/layouts/__tests__/LogoutAction.test.tsx -t "TopNav" — all 3 TopNav logout tests pass.
 pnpm vitest run src/lib/__tests__/walletsPrefetchCache.test.ts — pass.
 Manual check: sign in, open the user menu on desktop and a narrow mobile viewport, click Sign out, confirm redirect to /login and that a fresh sign-in doesn't show the previous session's wallets before refetching.
Closes #523